### PR TITLE
Replace nRF5 SDK Peer Manager with IOsonata PDS

### DIFF
--- a/ARM/Nordic/nRF52/src/bt_app_nrf52.cpp
+++ b/ARM/Nordic/nRF52/src/bt_app_nrf52.cpp
@@ -806,7 +806,7 @@ void BtSmpPasskeyReply(uint16_t ConnHdl, uint32_t Passkey)
 }
 
 // LE Secure Connections OOB data (strong overrides of the generic weak API).
-// On this port nrf_ble_lesc owns the SC key pair, so the local OOB set comes
+// The IOsonata BtLesc module owns the SC key pair, so the local OOB set comes
 // from it and the peer set is staged here; the peer data handler hands it to
 // the pairing with the link peer address filled in.
 static ble_gap_lesc_oob_data_t s_BtAppPeerOob;
@@ -908,9 +908,9 @@ static void ble_evt_dispatch(ble_evt_t const * p_ble_evt, void *p_context)
 	uint16_t role = ble_conn_state_role(p_ble_evt->evt.gap_evt.conn_handle);
 
 	// The LESC module receives BLE events through the peer_manager path:
-	// security_manager forwards every event to nrf_ble_lesc_on_ble_evt when
-	// PM_LESC_ENABLED is set. Calling it here as well would deliver each event
-	// twice and run sd_ble_gap_lesc_oob_data_set twice on an OOB DHKey
+	// sm_ble_evt_handler (bt_sec_sd.cpp) forwards every event to BtLescOnBleEvt
+	// as its single delivery point. Calling it here as well would deliver each
+	// event twice and run sd_ble_gap_lesc_oob_data_set twice on an OOB DHKey
 	// request, which latches the module internal error.
 
 	// Trace security-relevant GAP events to diagnose the pairing flow.
@@ -2003,9 +2003,8 @@ NRF_SDH_STACK_OBSERVER(m_nrf_sdh_soc_evts_poll, NRF_SDH_SOC_STACK_OBSERVER_PRIO)
 // security status and requires a valid key pointer: a NULL key returns
 // NRF_ERROR_INVALID_ADDR and the DHKey request stays unanswered until the SMP
 // transaction timeout. On failure reply with a random key instead, so the
-// pairing fails cleanly at the peer DHKey check, the same way the SDK
-// nrf_ble_lesc does. The peer-key table is sized from the SoftDevice link
-// configuration.
+// pairing fails cleanly at the peer DHKey check. The peer-key table is sized
+// from the SoftDevice link configuration.
 //
 extern "C" uint32_t BtLescDhKeyReply(uint16_t ConnHdl, uint8_t SecStatus,
 									 const ble_gap_lesc_dhkey_t *pDhKey)

--- a/exemples/bluetooth/pds_test.cpp
+++ b/exemples/bluetooth/pds_test.cpp
@@ -1,7 +1,64 @@
-// Host test harness for bt_pds. RAM medium with power-cut injection.
-// Cut model: the Nth programming operation (write or erase) is torn at a
-// chosen byte offset, then every following operation fails until reboot.
+/**-------------------------------------------------------------------------
+@example	pds_test.cpp
 
+@brief	Host test harness for the bt_pds peer data store.
+
+Builds and runs on a PC, not on a target board. It mounts the store on a
+RAM medium with NOR semantics (programming only clears bits, ascending
+order) and drives it through a reference model plus power-cut injection:
+the Nth programming operation (write or erase) is torn at a chosen byte
+offset, then every following operation fails until reboot.
+
+Build and run on the host:
+
+  g++ -std=gnu++23 -O1 -I include -o test_pds \
+      exemples/bluetooth/test_pds.cpp src/bluetooth/bt_pds.cpp
+  ./test_pds
+
+Coverage:
+  - Basic semantics: write/read/update/delete, tombstone vs zero length,
+    truncated read reporting, reserved id, oversize rejection.
+  - Churn: 20K writes over 2 sectors and 100K over 4 sectors against a
+    reference model, with remount checks.
+  - Fill to -ENOMEM and update behavior at capacity.
+  - Garbage collection cut sweep: a power cut at every programming
+    operation of a collecting write, three tear sizes each. After reboot
+    the store must mount and every committed value must read back.
+  - Clear cut sweep: a power cut at every programming operation of
+    BtPdsClear. After reboot the store must hold all records or none.
+
+The harness prints RESULT: ALL PASS on success and a FAIL line per
+violated check otherwise. This file is host-only and is not referenced
+by any board project.
+
+@author	Hoang Nguyen Hoan
+@date	Jul 19, 2026
+
+@license
+
+MIT License
+
+Copyright (c) 2026, I-SYST, all rights reserved
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+----------------------------------------------------------------------------*/
 #include <cstdio>
 #include <cstring>
 #include <cstdint>

--- a/exemples/bluetooth/test_pds.cpp
+++ b/exemples/bluetooth/test_pds.cpp
@@ -1,0 +1,419 @@
+// Host test harness for bt_pds. RAM medium with power-cut injection.
+// Cut model: the Nth programming operation (write or erase) is torn at a
+// chosen byte offset, then every following operation fails until reboot.
+
+#include <cstdio>
+#include <cstring>
+#include <cstdint>
+#include <cerrno>
+#include <vector>
+#include <map>
+
+#include "bluetooth/bt_pds.h"
+
+#define SECTOR_SIZE		512U
+#define MAX_REGION		(16U * SECTOR_SIZE)
+
+static uint8_t s_Flash[MAX_REGION];
+static uint32_t s_RegionSize;
+static int s_CutCountdown = -1;	// -1 disabled; 0 means next op is cut
+static uint32_t s_CutKeep;		// bytes of the cut op that still land
+static bool s_Dead;
+static int s_OpCount;
+
+static int NvmRead(uint32_t Off, void *pBuf, uint32_t Len)
+{
+	if (s_Dead || Off + Len > s_RegionSize) return -EIO;
+	memcpy(pBuf, &s_Flash[Off], Len);
+	return 0;
+}
+
+static int NvmWrite(uint32_t Off, const void *pData, uint32_t Len)
+{
+	if (s_Dead || Off + Len > s_RegionSize) return -EIO;
+	s_OpCount++;
+	uint32_t n = Len;
+	if (s_CutCountdown == 0)
+	{
+		n = s_CutKeep < Len ? s_CutKeep : Len;
+		s_Dead = true;
+	}
+	else if (s_CutCountdown > 0)
+	{
+		s_CutCountdown--;
+	}
+	// NOR model: programming can only clear bits. Ascending order.
+	const uint8_t *p = (const uint8_t *)pData;
+	for (uint32_t i = 0; i < n; i++)
+	{
+		s_Flash[Off + i] &= p[i];
+	}
+	return s_Dead ? -EIO : 0;
+}
+
+static int NvmErase(uint32_t Off)
+{
+	if (s_Dead || Off + SECTOR_SIZE > s_RegionSize) return -EIO;
+	s_OpCount++;
+	uint32_t n = SECTOR_SIZE;
+	if (s_CutCountdown == 0)
+	{
+		n = s_CutKeep < SECTOR_SIZE ? s_CutKeep : SECTOR_SIZE;
+		s_Dead = true;
+	}
+	else if (s_CutCountdown > 0)
+	{
+		s_CutCountdown--;
+	}
+	memset(&s_Flash[Off], 0xFF, n);
+	return s_Dead ? -EIO : 0;
+}
+
+static BtPdsNvm_t s_Nvm = {
+	0, 0, SECTOR_SIZE, 4, NvmRead, NvmWrite, NvmErase
+};
+
+static void PowerOn(void)
+{
+	s_Dead = false;
+	s_CutCountdown = -1;
+}
+
+static void FreshFlash(uint32_t Sectors)
+{
+	s_RegionSize = Sectors * SECTOR_SIZE;
+	s_Nvm.RegionSize = s_RegionSize;
+	memset(s_Flash, 0xFF, sizeof(s_Flash));
+	PowerOn();
+}
+
+static int g_Fail;
+
+#define CHECK(cond, ...) do { if (!(cond)) { g_Fail++; \
+	printf("FAIL %s:%d: ", __func__, __LINE__); printf(__VA_ARGS__); \
+	printf("\n"); } } while (0)
+
+// Reference model of expected content.
+typedef std::map<uint32_t, std::vector<uint8_t>> Model;
+
+static void VerifyModel(const Model &m, const char *Tag)
+{
+	for (const auto &kv : m)
+	{
+		uint8_t buf[BT_PDS_RECORD_DATA_MAX];
+		ssize_t r = BtPdsRead(kv.first, buf, sizeof(buf));
+		CHECK(r == (ssize_t)kv.second.size(),
+			  "%s id %u len %zd want %zu", Tag, kv.first, r, kv.second.size());
+		if (r == (ssize_t)kv.second.size() && r > 0)
+		{
+			CHECK(memcmp(buf, kv.second.data(), r) == 0,
+				  "%s id %u data mismatch", Tag, kv.first);
+		}
+	}
+}
+
+static std::vector<uint8_t> Val(uint32_t Id, uint32_t Rev, size_t Len)
+{
+	std::vector<uint8_t> v(Len);
+	for (size_t i = 0; i < Len; i++)
+	{
+		v[i] = (uint8_t)(Id * 7U + Rev * 13U + i);
+	}
+	return v;
+}
+
+static void TestBasic(void)
+{
+	FreshFlash(2);
+	CHECK(BtPdsInit(&s_Nvm) == 0, "init");
+	uint8_t buf[BT_PDS_RECORD_DATA_MAX];
+
+	CHECK(BtPdsRead(1, buf, sizeof(buf)) == -ENOENT, "absent");
+	auto v = Val(1, 0, 20);
+	CHECK(BtPdsWrite(1, v.data(), v.size()) == 20, "write");
+	CHECK(BtPdsRead(1, buf, sizeof(buf)) == 20, "read len");
+	CHECK(memcmp(buf, v.data(), 20) == 0, "read data");
+	CHECK(BtPdsRead(1, buf, 4) == 20, "truncated read reports full len");
+
+	auto v2 = Val(1, 1, 128);
+	CHECK(BtPdsWrite(1, v2.data(), v2.size()) == 128, "update max len");
+	CHECK(BtPdsRead(1, buf, sizeof(buf)) == 128, "read updated");
+	CHECK(memcmp(buf, v2.data(), 128) == 0, "updated data");
+
+	CHECK(BtPdsWrite(2, nullptr, 0) == 0, "zero length write");
+	CHECK(BtPdsRead(2, buf, sizeof(buf)) == 0, "zero length read");
+
+	CHECK(BtPdsDelete(1) == 0, "delete");
+	CHECK(BtPdsRead(1, buf, sizeof(buf)) == -ENOENT, "deleted");
+	CHECK(BtPdsDelete(1) == 0, "delete absent");
+
+	CHECK(BtPdsWrite(3, buf, BT_PDS_RECORD_DATA_MAX + 1) == -EINVAL, "oversize");
+	CHECK(BtPdsWrite(0xFFFFFFFEUL, buf, 4) == -EINVAL, "reserved id");
+
+	// Remount keeps everything.
+	CHECK(BtPdsInit(&s_Nvm) == 0, "remount");
+	CHECK(BtPdsRead(1, buf, sizeof(buf)) == -ENOENT, "deleted after remount");
+	CHECK(BtPdsRead(2, buf, sizeof(buf)) == 0, "zero len after remount");
+}
+
+static void TestChurn(uint32_t Sectors, int Writes)
+{
+	FreshFlash(Sectors);
+	CHECK(BtPdsInit(&s_Nvm) == 0, "init");
+	Model m;
+
+	// One cold id that is written once and rarely touched.
+	auto cold = Val(100, 0, 60);
+	CHECK(BtPdsWrite(100, cold.data(), cold.size()) == 60, "cold write");
+	m[100] = cold;
+
+	for (int i = 0; i < Writes; i++)
+	{
+		uint32_t id = 1 + (i % 3);
+		auto v = Val(id, i, 8 + (i % 5) * 24);
+		ssize_t r = BtPdsWrite(id, v.data(), v.size());
+		CHECK(r == (ssize_t)v.size(), "churn write %d ret %zd", i, r);
+		m[id] = v;
+		if (i % 977 == 0)
+		{
+			VerifyModel(m, "churn");
+		}
+	}
+	VerifyModel(m, "churn end");
+	CHECK(BtPdsInit(&s_Nvm) == 0, "remount");
+	VerifyModel(m, "churn remount");
+}
+
+// Fill until the store refuses, confirm -ENOMEM behavior is stable.
+static void TestFull(void)
+{
+	FreshFlash(2);
+	CHECK(BtPdsInit(&s_Nvm) == 0, "init");
+	Model m;
+	uint32_t id = 1;
+	for (;;)
+	{
+		auto v = Val(id, 0, 100);
+		ssize_t r = BtPdsWrite(id, v.data(), v.size());
+		if (r == -ENOMEM)
+		{
+			break;
+		}
+		CHECK(r == 100, "fill write ret %zd", r);
+		m[id] = v;
+		id++;
+		CHECK(id < 100, "no full condition reached");
+		if (id >= 100) return;
+	}
+	VerifyModel(m, "full");
+	CHECK(BtPdsInit(&s_Nvm) == 0, "remount full store");
+	VerifyModel(m, "full remount");
+	// At hard capacity an update may not fit either; the store must keep
+	// its data intact in both outcomes.
+	auto v = Val(1, 9, 100);
+	ssize_t ur = BtPdsWrite(1, v.data(), v.size());
+	CHECK(ur == 100 || ur == -ENOMEM, "update at capacity ret %zd", ur);
+	if (ur == 100)
+	{
+		m[1] = v;
+	}
+	VerifyModel(m, "full update");
+}
+
+// Defect 1: cut power at every programming op of a write whose EnsureSpace
+// runs a real garbage collection (op burst >= 5; StartSector costs 2).
+// After reboot, init must succeed and all committed values must read back.
+static void TestGcCutSweep(uint32_t Sectors)
+{
+	FreshFlash(Sectors);
+	CHECK(BtPdsInit(&s_Nvm) == 0, "init");
+	Model m;
+	std::vector<uint8_t> snap;
+	Model snapModel;
+	std::vector<uint8_t> trig;
+	uint32_t trigId = 0;
+	int totalOps = 0;
+
+	// Live set: 3 hot ids + 1 cold id at 72 bytes each keeps the whole set
+	// plus GC overhead inside one sector.
+	uint32_t hotIds = 3;
+	size_t recLen = 72;
+	// A cold id keeps at least one live record in the oldest sector so a
+	// garbage collection always copies something.
+	auto coldV = Val(99, 0, recLen);
+	CHECK(BtPdsWrite(99, coldV.data(), coldV.size()) == (ssize_t)recLen,
+		  "cold write");
+	m[99] = coldV;
+	for (uint32_t i = 1; i <= 400; i++)
+	{
+		// A fresh never-updated id every 5th write leaves one live record
+		// in every filled sector, so no victim allows a zero-copy
+		// collection and the swept collection has a real copy phase.
+		uint32_t id = (i % 5) == 0 ? 1000 + i : 1 + (i % hotIds);
+		auto v = Val(id, i, recLen);
+		snap.assign(s_Flash, s_Flash + s_RegionSize);
+		snapModel = m;
+		s_OpCount = 0;
+		ssize_t r = BtPdsWrite(id, v.data(), v.size());
+		CHECK(r == (ssize_t)recLen, "prefill ret %zd", r);
+		m[id] = v;
+		if (s_OpCount >= 5)
+		{
+			trig = v;
+			trigId = id;
+			totalOps = s_OpCount;
+			break;
+		}
+	}
+	CHECK(totalOps >= 5, "gc never triggered");
+	if (totalOps < 5) return;
+
+	int mountFail = 0;
+	for (int cut = 0; cut < totalOps; cut++)
+	{
+		for (uint32_t keep : {0U, 6U, 12U})
+		{
+			memcpy(s_Flash, snap.data(), s_RegionSize);
+			PowerOn();
+			CHECK(BtPdsInit(&s_Nvm) == 0, "mount before cut run");
+			s_CutCountdown = cut;
+			s_CutKeep = keep;
+			(void)BtPdsWrite(trigId, trig.data(), trig.size());
+
+			PowerOn();	// reboot
+			int r = BtPdsInit(&s_Nvm);
+			if (r != 0)
+			{
+				mountFail++;
+				printf("  cut %d keep %u: init %d\n", cut, keep, r);
+				continue;
+			}
+			// Every value committed before the interrupted write must read
+			// back, except the interrupted id, which may be old or new.
+			for (const auto &kv : snapModel)
+			{
+				uint8_t buf[BT_PDS_RECORD_DATA_MAX];
+				ssize_t rr = BtPdsRead(kv.first, buf, sizeof(buf));
+				if (kv.first == trigId)
+				{
+					CHECK(rr == (ssize_t)kv.second.size() ||
+						  rr == (ssize_t)recLen,
+						  "torn id state %zd", rr);
+					continue;
+				}
+				CHECK(rr == (ssize_t)kv.second.size(),
+					  "gc cut id %u len %zd want %zu",
+					  kv.first, rr, kv.second.size());
+				if (rr == (ssize_t)kv.second.size() && rr > 0)
+				{
+					CHECK(memcmp(buf, kv.second.data(), rr) == 0,
+						  "gc cut id %u data", kv.first);
+				}
+			}
+			auto post = Val(777, 1, 40);
+			ssize_t pr = BtPdsWrite(777, post.data(), post.size());
+			CHECK(pr == 40, "post-recovery write cut %d keep %u ret %zd",
+				  cut, keep, pr);
+		}
+	}
+	CHECK(mountFail == 0, "%d cut points failed to mount", mountFail);
+	printf("  gc cut sweep %u sectors: %d cut points x 3 tears\n",
+		   Sectors, totalOps);
+}
+
+// Defect 3: cut power at every programming op of BtPdsClear.
+// After reboot the store must hold all old records or none.
+static void TestClearCutSweep(uint32_t Sectors)
+{
+	FreshFlash(Sectors);
+	CHECK(BtPdsInit(&s_Nvm) == 0, "init");
+	Model m;
+	for (uint32_t i = 1; i <= 6; i++)
+	{
+		auto v = Val(i, 0, 40);
+		CHECK(BtPdsWrite(i, v.data(), v.size()) == 40, "populate");
+		m[i] = v;
+	}
+	// Force at least one GC so records spread across sectors.
+	for (int i = 0; i < 30; i++)
+	{
+		auto v = Val(3, i + 1, 40);
+		CHECK(BtPdsWrite(3, v.data(), v.size()) == 40, "spread");
+		m[3] = v;
+	}
+	std::vector<uint8_t> snap(s_Flash, s_Flash + s_RegionSize);
+
+	s_OpCount = 0;
+	CHECK(BtPdsClear() == 0, "clear");
+	int totalOps = s_OpCount;
+	CHECK(totalOps >= 2, "clear ops %d", totalOps);
+
+	int mixed = 0, mountFail = 0;
+	for (int cut = 0; cut < totalOps; cut++)
+	{
+		for (uint32_t keep : {0U, 8U, 200U})
+		{
+			memcpy(s_Flash, snap.data(), s_RegionSize);
+			PowerOn();
+			CHECK(BtPdsInit(&s_Nvm) == 0, "mount before clear run");
+			s_CutCountdown = cut;
+			s_CutKeep = keep;
+			(void)BtPdsClear();
+
+			PowerOn();
+			int r = BtPdsInit(&s_Nvm);
+			if (r != 0)
+			{
+				mountFail++;
+				printf("  clear cut %d keep %u: init %d\n", cut, keep, r);
+				continue;
+			}
+			int present = 0;
+			for (const auto &kv : m)
+			{
+				uint8_t buf[BT_PDS_RECORD_DATA_MAX];
+				if (BtPdsRead(kv.first, buf, sizeof(buf)) >= 0)
+				{
+					present++;
+				}
+			}
+			if (present != 0 && present != (int)m.size())
+			{
+				mixed++;
+				printf("  clear cut %d keep %u: %d of %zu resurrected\n",
+					   cut, keep, present, m.size());
+			}
+		}
+	}
+	CHECK(mountFail == 0, "%d clear cuts failed to mount", mountFail);
+	CHECK(mixed == 0, "%d clear cuts resurrected a partial set", mixed);
+	printf("  clear cut sweep %u sectors: %d cut points x 3 tears\n",
+		   Sectors, totalOps);
+
+	// A completed clear stays empty after remount.
+	memcpy(s_Flash, snap.data(), s_RegionSize);
+	PowerOn();
+	CHECK(BtPdsInit(&s_Nvm) == 0, "mount");
+	CHECK(BtPdsClear() == 0, "clean clear");
+	CHECK(BtPdsInit(&s_Nvm) == 0, "remount");
+	for (const auto &kv : m)
+	{
+		uint8_t buf[BT_PDS_RECORD_DATA_MAX];
+		CHECK(BtPdsRead(kv.first, buf, sizeof(buf)) == -ENOENT,
+			  "id %u after clean clear", kv.first);
+	}
+}
+
+int main(void)
+{
+	TestBasic();
+	TestChurn(2, 20000);
+	TestChurn(4, 100000);
+	TestFull();
+	TestGcCutSweep(2);
+	TestGcCutSweep(4);
+	TestClearCutSweep(2);
+	TestClearCutSweep(4);
+	printf(g_Fail ? "RESULT: %d FAILURES\n" : "RESULT: ALL PASS\n", g_Fail);
+	return g_Fail ? 1 : 0;
+}

--- a/include/bluetooth/bt_pds.h
+++ b/include/bluetooth/bt_pds.h
@@ -63,9 +63,9 @@ extern "C" {
 /**
  * @brief Mount the store on an NVM implementation.
  *
- * Scans every sector, recovers an interrupted garbage collection, and selects
- * the newest writable sector. The earlier development format without sector
- * headers is cleared once because it cannot be upgraded in place while
+ * Scans every sector, recovers or safely discards an interrupted garbage
+ * collection, and selects the newest writable sector. Earlier development
+ * formats are cleared once because they cannot be upgraded in place while
  * preserving the power-loss guarantee.
  *
  * @return 0 on success, negative errno on failure.
@@ -104,6 +104,10 @@ int BtPdsDelete(uint32_t Id);
 
 /**
  * @brief Erase all records and create a new empty active sector.
+ *
+ * The clear commits when one sector header under a new clear epoch reaches
+ * the medium. A power loss after that point cannot bring cleared records
+ * back; a power loss before it leaves the store unchanged.
  *
  * @return 0 on success or negative errno.
  */

--- a/src/bluetooth/bt_pds.cpp
+++ b/src/bluetooth/bt_pds.cpp
@@ -10,8 +10,17 @@
 		Garbage collection copies only the globally newest records from one
 		victim sector into the erased destination sector. The victim is erased
 		only after a completion marker is committed. If power is lost during the
-		copy or erase, BtPdsInit resumes the interrupted operation before the
-		store accepts new writes.
+		copy or erase, BtPdsInit resumes or safely discards the interrupted
+		operation before the store accepts new writes. Until the completion
+		marker commits, the victim still owns every record, so an unusable
+		destination is simply erased and the collection retried later.
+
+		Format 3. Record sequence numbers are 32 bit and never wrap within the
+		endurance of any supported medium, so newest-record selection is a plain
+		compare. Record and sector headers are protected by CRC16. Each sector
+		header records a clear epoch: BtPdsClear commits by writing one sector
+		header under the next epoch, and sectors under an older epoch are
+		ignored and erased at the next init.
 
 		The implementation uses a single record-sized scratch buffer. It does
 		not allocate a live-record table or use the heap.
@@ -30,7 +39,7 @@
 #define BT_PDS_REC_MAGIC			0x53445042UL	// "BPDS"
 #define BT_PDS_SECTOR_MAGIC		0x32534450UL	// "PDS2"
 #define BT_PDS_TOMBSTONE			0xFFFFU
-#define BT_PDS_FORMAT_VERSION		2U
+#define BT_PDS_FORMAT_VERSION		3U
 #define BT_PDS_NO_SECTOR			0xFFFFU
 #define BT_PDS_CTRL_GC_DONE_ID		0xFFFFFFFEUL
 #define BT_PDS_ERASED_U32			0xFFFFFFFFUL
@@ -44,21 +53,24 @@ typedef struct __Bt_Pds_Sector_Hdr {
 	uint32_t	Magic;
 	uint32_t	Generation;
 	uint32_t	SourceGeneration;
+	uint32_t	Epoch;
 	uint16_t	SourceSector;
 	uint16_t	Version;
-	uint8_t		Crc;
-	uint8_t		Rsvd[3];
+	uint16_t	Crc;
+	uint8_t		Rsvd[2];
 } BtPdsSectorHdr_t;
 
 typedef struct __Bt_Pds_Rec_Hdr {
 	uint32_t	Magic;
 	uint32_t	Id;
+	uint32_t	Seq;
 	uint16_t	Len;
-	uint16_t	Seq;
-	uint8_t		Crc;
-	uint8_t		Rsvd[3];
+	uint16_t	Crc;
 } BtPdsRecHdr_t;
 #pragma pack(pop)
+
+static_assert(sizeof(BtPdsSectorHdr_t) == 24, "sector header layout");
+static_assert(sizeof(BtPdsRecHdr_t) == 16, "record header layout");
 
 #define BT_PDS_SECTOR_HDR_SIZE	((uint32_t)sizeof(BtPdsSectorHdr_t))
 #define BT_PDS_REC_HDR_SIZE		((uint32_t)sizeof(BtPdsRecHdr_t))
@@ -77,7 +89,7 @@ typedef struct __Bt_Pds_Sector_Info {
 typedef struct __Bt_Pds_Latest {
 	bool		Found;
 	bool		Tombstone;
-	uint16_t	Seq;
+	uint32_t	Seq;
 	uint16_t	Len;
 	uint16_t	Sector;
 	uint32_t	Off;
@@ -87,10 +99,11 @@ static const BtPdsNvm_t *s_pNvm;
 static BtPdsSectorInfo_t s_Sectors[BT_PDS_MAX_SECTORS];
 static uint16_t s_SectorCount;
 static uint16_t s_ActiveSector;
-static uint16_t s_NextSeq;
+static uint32_t s_NextSeq;
 static uint32_t s_NextGeneration;
+static uint32_t s_Epoch;
 static bool s_SeqFound;
-static uint16_t s_MaxSeq;
+static uint32_t s_MaxSeq;
 
 static inline uint32_t WordPad(uint32_t x)
 {
@@ -112,47 +125,43 @@ static inline uint32_t SectorDataStart(uint16_t Sector)
 	return SectorBase(Sector) + BT_PDS_SECTOR_HDR_SIZE;
 }
 
-static inline bool SeqNewer(uint16_t A, uint16_t B)
+static uint16_t Crc16(const void *pData, uint32_t Len, uint16_t Seed)
 {
-	uint16_t d = (uint16_t)(A - B);
-	return d != 0U && d < 0x8000U;
-}
-
-static uint8_t Crc8(const void *pData, uint32_t Len, uint8_t Seed)
-{
+	// CRC16-CCITT, polynomial 0x1021.
 	const uint8_t *p = (const uint8_t *)pData;
-	uint8_t crc = Seed;
+	uint16_t crc = Seed;
 
 	for (uint32_t i = 0; i < Len; i++)
 	{
-		crc ^= p[i];
+		crc ^= (uint16_t)((uint16_t)p[i] << 8);
 		for (int b = 0; b < 8; b++)
 		{
-			crc = (crc & 0x80U) ?
-				(uint8_t)((crc << 1) ^ 0x07U) :
-				(uint8_t)(crc << 1);
+			crc = (crc & 0x8000U) ?
+				(uint16_t)((crc << 1) ^ 0x1021U) :
+				(uint16_t)(crc << 1);
 		}
 	}
 	return crc;
 }
 
-static uint8_t SectorHdrCrc(const BtPdsSectorHdr_t *pHdr)
+static uint16_t SectorHdrCrc(const BtPdsSectorHdr_t *pHdr)
 {
-	uint8_t crc = Crc8(&pHdr->Generation, sizeof(pHdr->Generation), 0xFFU);
-	crc = Crc8(&pHdr->SourceGeneration, sizeof(pHdr->SourceGeneration), crc);
-	crc = Crc8(&pHdr->SourceSector, sizeof(pHdr->SourceSector), crc);
-	crc = Crc8(&pHdr->Version, sizeof(pHdr->Version), crc);
+	uint16_t crc = Crc16(&pHdr->Generation, sizeof(pHdr->Generation), 0xFFFFU);
+	crc = Crc16(&pHdr->SourceGeneration, sizeof(pHdr->SourceGeneration), crc);
+	crc = Crc16(&pHdr->Epoch, sizeof(pHdr->Epoch), crc);
+	crc = Crc16(&pHdr->SourceSector, sizeof(pHdr->SourceSector), crc);
+	crc = Crc16(&pHdr->Version, sizeof(pHdr->Version), crc);
 	return crc;
 }
 
-static uint8_t RecCrc(const BtPdsRecHdr_t *pHdr, const void *pData)
+static uint16_t RecCrc(const BtPdsRecHdr_t *pHdr, const void *pData)
 {
-	uint8_t crc = Crc8(&pHdr->Id, sizeof(pHdr->Id), 0xFFU);
-	crc = Crc8(&pHdr->Len, sizeof(pHdr->Len), crc);
-	crc = Crc8(&pHdr->Seq, sizeof(pHdr->Seq), crc);
+	uint16_t crc = Crc16(&pHdr->Id, sizeof(pHdr->Id), 0xFFFFU);
+	crc = Crc16(&pHdr->Len, sizeof(pHdr->Len), crc);
+	crc = Crc16(&pHdr->Seq, sizeof(pHdr->Seq), crc);
 	if (pHdr->Len != BT_PDS_TOMBSTONE && pHdr->Len > 0U)
 	{
-		crc = Crc8(pData, pHdr->Len, crc);
+		crc = Crc16(pData, pHdr->Len, crc);
 	}
 	return crc;
 }
@@ -258,6 +267,17 @@ static int ScanSector(uint16_t Sector)
 		return 0;
 	}
 
+	if (sectorHdr.Epoch != s_Epoch)
+	{
+		// Sector under an earlier epoch: cleared by BtPdsClear but not yet
+		// erased. Its records are ignored and it is erased at init.
+		pInfo->Valid = false;
+		pInfo->Erased = false;
+		pInfo->Writable = false;
+		pInfo->Head = SectorEnd(Sector);
+		return 0;
+	}
+
 	pInfo->Valid = true;
 	pInfo->Erased = false;
 	pInfo->Writable = true;
@@ -297,7 +317,7 @@ static int ScanSector(uint16_t Sector)
 			pInfo->GcDone = true;
 		}
 
-		if (!s_SeqFound || SeqNewer(hdr.Seq, s_MaxSeq))
+		if (!s_SeqFound || hdr.Seq > s_MaxSeq)
 		{
 			s_SeqFound = true;
 			s_MaxSeq = hdr.Seq;
@@ -331,9 +351,10 @@ static int WriteSectorHdr(uint16_t Sector, uint16_t SourceSector,
 	hdr.Magic = BT_PDS_SECTOR_MAGIC;
 	hdr.Generation = s_NextGeneration++;
 	hdr.SourceGeneration = SourceGeneration;
+	hdr.Epoch = s_Epoch;
 	hdr.SourceSector = SourceSector;
 	hdr.Version = BT_PDS_FORMAT_VERSION;
-	hdr.Rsvd[0] = hdr.Rsvd[1] = hdr.Rsvd[2] = 0U;
+	hdr.Rsvd[0] = hdr.Rsvd[1] = 0U;
 	hdr.Crc = SectorHdrCrc(&hdr);
 
 	if (s_pNvm->Write(SectorBase(Sector), &hdr, sizeof(hdr)) != 0)
@@ -418,7 +439,7 @@ static bool FindLatest(uint32_t Id, BtPdsLatest_t *pLatest)
 			}
 
 			if (hdr.Id == Id && hdr.Id != BT_PDS_CTRL_GC_DONE_ID &&
-				(!latest.Found || SeqNewer(hdr.Seq, latest.Seq)))
+				(!latest.Found || hdr.Seq > latest.Seq))
 			{
 				latest.Found = true;
 				latest.Tombstone = hdr.Len == BT_PDS_TOMBSTONE;
@@ -510,7 +531,11 @@ static int CopyLatestFromSector(uint16_t Victim, uint16_t Destination)
 		BtPdsRecHdr_t hdr;
 		if (!ReadRecord(Victim, off, &hdr, data))
 		{
-			return -EIO;
+			// An unreadable record ends the sector log, exactly as it does
+			// for ScanSector, FindLatest and SectorCopyBytes. A victim that
+			// was closed by a torn append ends this way and everything
+			// after the tear is uncommitted, so the copy is complete here.
+			break;
 		}
 
 		uint32_t next = off + RecSize(hdr.Len);
@@ -550,16 +575,32 @@ static int CompleteGc(uint16_t Destination)
 
 	if (!pDest->GcDone)
 	{
-		int result = CopyLatestFromSector(source, Destination);
-		if (result != 0)
+		int result;
+
+		if (!pDest->Writable)
 		{
-			return result;
+			// A torn record from the interrupted copy closed the destination.
+			result = -EIO;
+		}
+		else
+		{
+			result = CopyLatestFromSector(source, Destination);
+			if (result == 0)
+			{
+				result = AppendToSector(Destination, BT_PDS_CTRL_GC_DONE_ID,
+										0U, nullptr);
+			}
 		}
 
-		result = AppendToSector(Destination, BT_PDS_CTRL_GC_DONE_ID, 0U, nullptr);
 		if (result != 0)
 		{
-			return result;
+			// Until the completion marker commits, the source sector still
+			// owns every record and the destination holds only value-identical
+			// duplicates. No user write can land in the destination before the
+			// collection completes, so it is erased and the collection is
+			// retried later instead of leaving the store unmountable.
+			result = EraseSector(Destination);
+			return result != 0 ? result : -EAGAIN;
 		}
 		pDest->GcDone = true;
 	}
@@ -572,6 +613,19 @@ static int ScanAll(void)
 	s_SeqFound = false;
 	s_MaxSeq = 0U;
 	s_NextGeneration = 1U;
+	s_Epoch = 0U;
+
+	// The current epoch is the highest one present on the medium. Sectors
+	// under an earlier epoch were cleared by BtPdsClear before power was
+	// lost and must stay invisible.
+	for (uint16_t sector = 0; sector < s_SectorCount; sector++)
+	{
+		BtPdsSectorHdr_t hdr;
+		if (ReadSectorHdr(sector, &hdr) && hdr.Epoch > s_Epoch)
+		{
+			s_Epoch = hdr.Epoch;
+		}
+	}
 
 	for (uint16_t sector = 0; sector < s_SectorCount; sector++)
 	{
@@ -602,7 +656,7 @@ static int RecoverGc(void)
 			s_Sectors[sector].SourceSector != BT_PDS_NO_SECTOR)
 		{
 			int result = CompleteGc(sector);
-			if (result != 0)
+			if (result != 0 && result != -EAGAIN)
 			{
 				return result;
 			}
@@ -730,7 +784,9 @@ static int GarbageCollect(uint32_t Need)
 	result = CompleteGc(destination);
 	if (result != 0)
 	{
-		return result;
+		// -EAGAIN reports an aborted copy. The destination was erased and the
+		// store stays consistent, but the requested write did not happen.
+		return result == -EAGAIN ? -EIO : result;
 	}
 
 	s_ActiveSector = destination;
@@ -775,6 +831,7 @@ static int FormatStore(void)
 
 	s_NextSeq = 0U;
 	s_NextGeneration = 1U;
+	s_Epoch = 0U;
 	return StartSector(0U);
 }
 
@@ -800,9 +857,11 @@ int BtPdsInit(const BtPdsNvm_t *pNvm)
 	s_SectorCount = (uint16_t)sectorCount;
 	s_ActiveSector = BT_PDS_NO_SECTOR;
 
-	// Format 1 began directly with a record and had no recoverable sector
-	// transaction. It cannot be upgraded in place while preserving the power
-	// loss guarantee, so clear that development format once.
+	// Development format 1 began directly with a record and had no
+	// recoverable sector transaction; it is detected here and cleared once.
+	// Development format 2 sectors fail header validation (layout and
+	// version changed) and are erased by the sweep below. Neither can be
+	// upgraded in place while preserving the power loss guarantee.
 	uint32_t firstWord = BT_PDS_ERASED_U32;
 	if (s_pNvm->Read(0U, &firstWord, sizeof(firstWord)) != 0)
 	{
@@ -819,8 +878,10 @@ int BtPdsInit(const BtPdsNvm_t *pNvm)
 		return result;
 	}
 
-	// A partial sector header contains no committed records. Its source sector
-	// still owns the data, so the partial destination can be erased safely.
+	// A partial sector header contains no committed records and its source
+	// sector still owns the data, so the partial destination can be erased
+	// safely. Sectors under an earlier epoch were cleared by BtPdsClear and
+	// are erased here as well.
 	for (uint16_t sector = 0; sector < s_SectorCount; sector++)
 	{
 		if (!s_Sectors[sector].Valid && !s_Sectors[sector].Erased)
@@ -921,5 +982,37 @@ int BtPdsClear(void)
 	{
 		return -EINVAL;
 	}
-	return FormatStore();
+
+	uint16_t spare = FindErasedSector();
+	if (spare == BT_PDS_NO_SECTOR)
+	{
+		// No erased spare exists only in an already-degraded state. Fall back
+		// to the sequential format, which is not power-loss atomic.
+		return FormatStore();
+	}
+
+	// Commit point of the clear. Once a sector header under the next epoch
+	// is on the medium, every sector under an earlier epoch is ignored and
+	// erased at the next init, so a power loss after this write cannot bring
+	// cleared records back. A power loss before it leaves the store
+	// unchanged.
+	s_Epoch++;
+	int result = StartSector(spare);
+	if (result != 0)
+	{
+		return result;
+	}
+
+	for (uint16_t sector = 0; sector < s_SectorCount; sector++)
+	{
+		if (sector != spare && !s_Sectors[sector].Erased)
+		{
+			result = EraseSector(sector);
+			if (result != 0)
+			{
+				return result;
+			}
+		}
+	}
+	return 0;
 }


### PR DESCRIPTION
Squash merge `replacing_sdk_peer_manager` into `master`.

This branch updates the nRF52 Bluetooth application to use the IOsonata peer-data storage implementation and adds a dedicated PDS test.