### PR TITLE
sync bt_conformance into compliance validation branch

### DIFF
--- a/include/bluetooth/bt_dev.h
+++ b/include/bluetooth/bt_dev.h
@@ -115,6 +115,12 @@ typedef struct __Bt_Device {
 	} TxPend[BT_DEV_TXPEND_MAX];
 	uint8_t			TxPendHead;					//!< Ring read index
 	uint8_t			TxPendCount;				//!< Ring occupancy in entries
+	//!< HCI packets in flight that belong to no GATT operation: ATT responses,
+	//!< SMP, L2CAP signaling. They own no callback but the controller still
+	//!< reports them, so they are counted here and taken off first. Without
+	//!< this their completions drained the ring and fired the next
+	//!< notification's callback before it had gone out.
+	uint16_t		TxUntracked;
 } BtDevice_t;
 
 #ifdef __cplusplus

--- a/include/bluetooth/bt_gatt.h
+++ b/include/bluetooth/bt_gatt.h
@@ -190,6 +190,7 @@ bool BtGattCharIndicate(uint16_t ConnHdl, BtGattChar_t *pChar, void * const pVal
 bool BtGattTxPendReserve(uint16_t ConnHdl, BtGattChar_t *pChar, uint16_t NbPkt);
 void BtGattTxPendRelease(uint16_t ConnHdl);
 void BtGattTxPendUntracked(uint16_t ConnHdl, uint16_t NbPkt);
+void BtGattTxPendingAdd(uint16_t ConnHdl, BtGattChar_t *pChar);
 void BtGattHandleValueConfirm(uint16_t ConnHdl);
 
 uint16_t BtGattCccdGet(uint16_t ConnHdl, uint16_t CccdHdl);

--- a/src/bluetooth/bt_app.cpp
+++ b/src/bluetooth/bt_app.cpp
@@ -89,6 +89,7 @@ BtAppData_t g_BtAppData = {
 		.TxPend     = {},
 		.TxPendHead = 0,
 		.TxPendCount = 0,
+		.TxUntracked = 0,
 	},
 };
 
@@ -128,12 +129,10 @@ static bool BtAppStoreValue(BtGattChar_t *pChar, uint8_t *pData, uint16_t DataLe
 		return false;
 	}
 
-	if (DataLen > 0 && BtGattCharSetValue(pChar, pData, DataLen) == false)
-	{
-		return false;
-	}
-
-	return true;
+	// A zero-length value is a value. Skipping the store left the previous
+	// contents readable after a zero-length notification, so a Read returned
+	// something the client had just been told was gone.
+	return BtGattCharSetValue(pChar, pData, DataLen);
 }
 
 // Resolve the one connected link. Returns false when none is up and when more
@@ -214,15 +213,23 @@ __attribute__((weak)) int BtAppNotifyAll(BtGattChar_t *pChar, uint8_t *pData, ui
 		return 0;
 	}
 
-	uint16_t hdl[BT_APP_LINK_MAX];
-	size_t n = BtPeerGetConnectedHandles(hdl, BT_APP_LINK_MAX);
+	// Walk the peer pool itself. A fixed local array silently skipped every
+	// link past its size, and the pool is sized by the caller's memory, not by
+	// a constant here.
+	uint16_t n = BtPeerCount();
 	int sent = 0;
 
-	for (size_t i = 0; i < n; i++)
+	for (uint16_t i = 0; i < n; i++)
 	{
+		BtDevice_t *pPeer = BtPeerSlot(i);
+		if (pPeer == nullptr || pPeer->Conn.Hdl == BT_CONN_HDL_INVALID)
+		{
+			continue;
+		}
+
 		// A link whose client did not subscribe is skipped by
 		// BtGattCharNotify, so it is not counted.
-		if (BtGattCharNotify(hdl[i], pChar, pData, DataLen))
+		if (BtGattCharNotify(pPeer->Conn.Hdl, pChar, pData, DataLen))
 		{
 			sent++;
 		}
@@ -238,16 +245,24 @@ __attribute__((weak)) int BtAppIndicateAll(BtGattChar_t *pChar, uint8_t *pData, 
 		return 0;
 	}
 
-	uint16_t hdl[BT_APP_LINK_MAX];
-	size_t n = BtPeerGetConnectedHandles(hdl, BT_APP_LINK_MAX);
+	// Walk the peer pool itself. A fixed local array silently skipped every
+	// link past its size, and the pool is sized by the caller's memory, not by
+	// a constant here.
+	uint16_t n = BtPeerCount();
 	int sent = 0;
 
-	for (size_t i = 0; i < n; i++)
+	for (uint16_t i = 0; i < n; i++)
 	{
+		BtDevice_t *pPeer = BtPeerSlot(i);
+		if (pPeer == nullptr || pPeer->Conn.Hdl == BT_CONN_HDL_INVALID)
+		{
+			continue;
+		}
+
 		// A link that already has an indication outstanding is refused until
 		// its confirmation arrives, so the count can be below the number of
 		// subscribed links.
-		if (BtGattCharIndicate(hdl[i], pChar, pData, DataLen))
+		if (BtGattCharIndicate(pPeer->Conn.Hdl, pChar, pData, DataLen))
 		{
 			sent++;
 		}
@@ -270,15 +285,25 @@ __attribute__((weak)) void BtAppDisconnect(void)
 
 __attribute__((weak)) int BtAppDisconnectAll(void)
 {
-	uint16_t hdl[BT_APP_LINK_MAX];
-	size_t n = BtPeerGetConnectedHandles(hdl, BT_APP_LINK_MAX);
+	// Walk the peer pool itself. A fixed local array silently skipped every
+	// link past its size, and the pool is sized by the caller's memory, not by
+	// a constant here.
+	uint16_t n = BtPeerCount();
+	int dropped = 0;
 
-	for (size_t i = 0; i < n; i++)
+	for (uint16_t i = 0; i < n; i++)
 	{
-		BtAppDisconnectConn(hdl[i]);
+		BtDevice_t *pPeer = BtPeerSlot(i);
+		if (pPeer == nullptr || pPeer->Conn.Hdl == BT_CONN_HDL_INVALID)
+		{
+			continue;
+		}
+
+		BtAppDisconnectConn(pPeer->Conn.Hdl);
+		dropped++;
 	}
 
-	return (int)n;
+	return dropped;
 }
 
 // --- BtDevice queries (work on any BtDevice_t, local or remote) ---

--- a/src/bluetooth/bt_gatt.cpp
+++ b/src/bluetooth/bt_gatt.cpp
@@ -551,13 +551,11 @@ void BtGattTxPendRelease(uint16_t ConnHdl)
 
 // Account for HCI packets this link sent that carry no GATT completion: ATT
 // responses, SMP PDUs, L2CAP signaling. They own no callback but the controller
-// still reports them, and without an entry of their own their completions drain
-// the ring and fire someone else's callback early.
+// still reports them, and without this their completions drain the ring and
+// fire someone else's callback early.
 //
-// Consecutive untracked packets coalesce into one entry, so ordinary request
-// and response traffic does not consume the ring. If there is no room at all
-// the count is added to the last entry instead of being dropped: that delays a
-// callback rather than firing it early, which is the safe direction to err.
+// They are counted rather than given ring entries, so ordinary request and
+// response traffic cannot exhaust the ring and refuse a notification.
 void BtGattTxPendUntracked(uint16_t ConnHdl, uint16_t NbPkt)
 {
 	BtDevice_t *pConn = BtPeerFindByHdl(ConnHdl);
@@ -567,20 +565,14 @@ void BtGattTxPendUntracked(uint16_t ConnHdl, uint16_t NbPkt)
 		return;
 	}
 
-	if (pConn->TxPendCount > 0)
-	{
-		uint8_t tail = (uint8_t)((pConn->TxPendHead + pConn->TxPendCount - 1) %
-								 BT_DEV_TXPEND_MAX);
+	pConn->TxUntracked = (uint16_t)(pConn->TxUntracked + NbPkt);
+}
 
-		if (pConn->TxPend[tail].pChar == nullptr ||
-			pConn->TxPendCount >= BT_DEV_TXPEND_MAX)
-		{
-			pConn->TxPend[tail].Remain = (uint16_t)(pConn->TxPend[tail].Remain + NbPkt);
-			return;
-		}
-	}
-
-	BtGattTxPendReserve(ConnHdl, nullptr, NbPkt);
+// Single-packet reservation, kept for callers that send one packet and do not
+// care to say so.
+void BtGattTxPendingAdd(uint16_t ConnHdl, BtGattChar_t *pChar)
+{
+	BtGattTxPendReserve(ConnHdl, pChar, 1);
 }
 
 // Number of HCI ACL packets a PDU of AclLen octets is sent as. The controller
@@ -1000,6 +992,14 @@ void BtGattSendCompleted(uint16_t ConnHdl, uint16_t NbPktSent)
 	// and a group with no owner (an ATT response, SMP, L2CAP signaling) absorbs
 	// its own completions instead of firing someone else's callback.
 	uint16_t n = NbPktSent;
+
+	// Packets no GATT operation owns come off first. They were sent on this
+	// link and the controller is reporting them; charging them to the head
+	// group is what fired callbacks early.
+	uint16_t foreign = min(n, pConn->TxUntracked);
+	pConn->TxUntracked = (uint16_t)(pConn->TxUntracked - foreign);
+	n = (uint16_t)(n - foreign);
+
 	while (n > 0 && pConn->TxPendCount > 0)
 	{
 		uint16_t take = min(n, pConn->TxPend[pConn->TxPendHead].Remain);

--- a/src/bluetooth/bt_hci_host.cpp
+++ b/src/bluetooth/bt_hci_host.cpp
@@ -115,6 +115,60 @@ typedef struct __Bt_ExtAdv_Reassembly {
 
 static BtExtAdvReasm_t s_BtExtAdvReasm[BT_EXT_ADV_REASSEMBLY_COUNT];
 
+// Advertisers whose reassembly was abandoned, because no context was free or
+// because the accumulated data overflowed. Their remaining fragments must not
+// be mistaken for standalone reports: the terminating fragment of a dropped
+// reassembly looks exactly like a complete single-fragment report, and
+// delivering it hands the application a truncated suffix as if it were whole
+// advertising data.
+#ifndef BT_EXT_ADV_DROPPED_COUNT
+#define BT_EXT_ADV_DROPPED_COUNT		4
+#endif
+
+typedef struct __Bt_ExtAdv_Dropped {
+	bool    Active;							//!< Slot names a dropped reassembly
+	uint8_t AddrType;						//!< Advertiser address type
+	uint8_t Addr[6];						//!< Advertiser address
+	uint8_t Sid;							//!< Advertising SID
+} BtExtAdvDropped_t;
+
+static BtExtAdvDropped_t s_BtExtAdvDropped[BT_EXT_ADV_DROPPED_COUNT];
+static uint8_t s_BtExtAdvDroppedNext = 0;
+
+static BtExtAdvDropped_t *BtExtAdvDroppedFind(uint8_t AddrType,
+											  const uint8_t Addr[6], uint8_t Sid)
+{
+	for (int i = 0; i < BT_EXT_ADV_DROPPED_COUNT; i++)
+	{
+		BtExtAdvDropped_t *d = &s_BtExtAdvDropped[i];
+		if (d->Active && d->AddrType == AddrType && d->Sid == Sid &&
+			memcmp(d->Addr, Addr, 6) == 0)
+		{
+			return d;
+		}
+	}
+	return nullptr;
+}
+
+// Oldest entry is overwritten. Losing the record of a very old dropped
+// reassembly only risks delivering one stale suffix; holding the table open
+// forever would be worse.
+static void BtExtAdvDroppedMark(uint8_t AddrType, const uint8_t Addr[6], uint8_t Sid)
+{
+	if (BtExtAdvDroppedFind(AddrType, Addr, Sid) != nullptr)
+	{
+		return;
+	}
+
+	BtExtAdvDropped_t *d = &s_BtExtAdvDropped[s_BtExtAdvDroppedNext];
+	s_BtExtAdvDroppedNext = (uint8_t)((s_BtExtAdvDroppedNext + 1) % BT_EXT_ADV_DROPPED_COUNT);
+
+	d->Active = true;
+	d->AddrType = AddrType;
+	d->Sid = Sid;
+	memcpy(d->Addr, Addr, 6);
+}
+
 static BtExtAdvReasm_t *BtExtAdvReasmFind(uint8_t AddrType, const uint8_t Addr[6], uint8_t Sid)
 {
 	for (int i = 0; i < BT_EXT_ADV_REASSEMBLY_COUNT; i++)
@@ -180,6 +234,15 @@ void BtHciProcessLeEvent(BtHciDevice_t * const pDev, BtHciLeEvtPacket_t *pLeEvtP
 		case BT_HCI_EVT_LE_ADV_REPORT:
 			{
 				BtHciLeEvtAdvReport_t *report = (BtHciLeEvtAdvReport_t*)pLeEvtPkt->Data;
+
+				// The dispatcher proved the subevent byte exists, not the count
+				// byte after it. Reading NbReport before checking is an
+				// out-of-bounds read on a truncated event.
+				if ((const uint8_t*)pLeEvtPkt->Data + 1 > evtEnd)
+				{
+					break;
+				}
+
 				// Each BtAdvReport_t is variable-length: 9-byte fixed header
 				// (EvtType, AddrType, Addr[6], DataLen) + Data[DataLen] +
 				// 1 byte trailing RSSI. Walk by stride, do not index as
@@ -327,6 +390,14 @@ void BtHciProcessLeEvent(BtHciDevice_t * const pDev, BtHciLeEvtPacket_t *pLeEvtP
 		case BT_HCI_EVT_LE_EXT_ADV_REPORT:
 			{
 				BtHciLeEvtExtAdvReport_t *report = (BtHciLeEvtExtAdvReport_t*)pLeEvtPkt->Data;
+
+				// Same as the legacy report: prove the count byte is inside the
+				// event before reading it.
+				if ((const uint8_t*)pLeEvtPkt->Data + 1 > evtEnd)
+				{
+					break;
+				}
+
 				// Each BtExtAdvReport_t is variable-length: 24-byte fixed
 				// header + Data[DataLen]. Walk by stride.
 				uint8_t *cur = (uint8_t*)report->Report;
@@ -355,7 +426,8 @@ void BtHciProcessLeEvent(BtHciDevice_t * const pDev, BtHciLeEvtPacket_t *pLeEvtP
 					if (dataStatus == 1)
 					{
 						// More data to come: buffer this fragment.
-						if (ctx == nullptr)
+						if (ctx == nullptr &&
+							BtExtAdvDroppedFind(r->AddrType, r->Addr, r->AdvSid) == nullptr)
 						{
 							ctx = BtExtAdvReasmAlloc(r->AddrType, r->Addr, r->AdvSid);
 						}
@@ -371,7 +443,15 @@ void BtHciProcessLeEvent(BtHciDevice_t * const pDev, BtHciLeEvtPacket_t *pLeEvtP
 								// Reassembly buffer would overflow: drop the
 								// partial report rather than deliver a truncation.
 								ctx->Active = false;
+								BtExtAdvDroppedMark(r->AddrType, r->Addr, r->AdvSid);
 							}
+						}
+						else
+						{
+							// No context free, or this advertiser is already
+							// abandoned. Either way the report cannot be
+							// reassembled and its tail must not be delivered.
+							BtExtAdvDroppedMark(r->AddrType, r->Addr, r->AdvSid);
 						}
 					}
 					else if (dataStatus == 0)
@@ -391,9 +471,24 @@ void BtHciProcessLeEvent(BtHciDevice_t * const pDev, BtHciLeEvtPacket_t *pLeEvtP
 							}
 							ctx->Active = false;
 						}
-						else if (pDev->ScanReport)
+						else
 						{
-							pDev->ScanReport(r->Rssi, r->AddrType, r->Addr, r->DataLen, r->Data);
+							// No context. Either this is a standalone complete
+							// report, or it is the tail of a reassembly that was
+							// abandoned, which looks identical on the wire.
+							// Delivering the second case hands the application a
+							// truncated suffix as whole advertising data.
+							BtExtAdvDropped_t *d =
+								BtExtAdvDroppedFind(r->AddrType, r->Addr, r->AdvSid);
+
+							if (d != nullptr)
+							{
+								d->Active = false;
+							}
+							else if (pDev->ScanReport)
+							{
+								pDev->ScanReport(r->Rssi, r->AddrType, r->Addr, r->DataLen, r->Data);
+							}
 						}
 					}
 					else
@@ -816,12 +911,20 @@ void BtHciProcessEvent(BtHciDevice_t *pDev, BtHciEvtPacket_t *pEvtPkt)
 //				{
 //					DEBUG_PRINTF("Hdl: %x - NbPkt: %d\r\n", p->Completed[i].Hdl, p->Completed[i].NbPkt);
 //				}
+				// The count byte has to be inside the event before it can be
+				// read. The clamp below bounded the walk but the read itself
+				// came first, which is an out-of-bounds read on a zero-length
+				// event however the walk then behaves.
+				if (pEvtPkt->Hdr.Len < 1)
+				{
+					break;
+				}
+
 				// NbHdl is controller-supplied; bound the walk to the entries the
 				// event length can actually hold (1 count byte + 4 bytes each) so
 				// a malformed event cannot read past the received payload.
 				int nbHdl = p->NbHdl;
-				int maxHdl = pEvtPkt->Hdr.Len >= 1 ?
-							 (pEvtPkt->Hdr.Len - 1) / (int)sizeof(p->Completed[0]) : 0;
+				int maxHdl = (pEvtPkt->Hdr.Len - 1) / (int)sizeof(p->Completed[0]);
 				if (nbHdl > maxHdl)
 				{
 					nbHdl = maxHdl;

--- a/src/bluetooth/bt_l2cap.cpp
+++ b/src/bluetooth/bt_l2cap.cpp
@@ -96,6 +96,28 @@ static bool BtL2CapAppendCmdReject(uint8_t *pOut, uint16_t *pOutLen, uint16_t Ou
 							  Id, payload, (uint16_t)(sizeof(uint16_t) + DataLen));
 }
 
+// An identified response is not answered with a Command Reject (Vol 3 Part A
+// 4.1). A packet whose first command is one of these is discarded when it
+// cannot be processed, otherwise two implementations that both reject on sight
+// can answer each other's rejects.
+static bool BtL2CapCodeIsResponse(uint8_t Code)
+{
+	switch (Code)
+	{
+		case BT_L2CAP_CODE_COMMAND_REJECT_RSP:
+		case BT_L2CAP_CODE_CONNECTION_PARAMETER_UPDATE_RSP:
+		case BT_L2CAP_CODE_LE_CREDIT_BASED_CONNECTION_RSP:
+		case BT_L2CAP_CODE_DISCONNECTION_RSP:
+		case BT_L2CAP_CODE_CREDIT_BASED_CONNECTION_RSP:
+		case BT_L2CAP_CODE_CREDIT_BASED_RECONFIGURE_RSP:
+			return true;
+		default:
+			break;
+	}
+
+	return false;
+}
+
 static bool BtL2CapConnParamValid(const BtL2CapConnParamUpdateReq_t *pReq)
 {
 	if (pReq == nullptr)
@@ -254,10 +276,21 @@ uint32_t BtL2CapProcessSignal(BtHciDevice_t * const pDev,
 	// is already known to be wrong.
 	if (ReqLen > BT_L2CAP_LE_SIG_MTU)
 	{
+		uint8_t code = ((BtL2CapCFrame_t const *)p)->Code;
+		uint8_t id = ((BtL2CapCFrame_t const *)p)->Id;
+
+		// Identifier 0 is reserved and never valid on a signaling command
+		// (Vol 3 Part A 4). Nothing can be echoed back, so discard.
+		if (BtL2CapCodeIsResponse(code) || id == 0)
+		{
+			pRspPdu->Hdr.Len = 0;
+
+			return 0;
+		}
+
 		uint16_t sigMtu = BT_L2CAP_LE_SIG_MTU;
 
-		BtL2CapAppendCmdReject(pOut, &outLen, outMax,
-								((BtL2CapCFrame_t const *)p)->Id,
+		BtL2CapAppendCmdReject(pOut, &outLen, outMax, id,
 								BT_L2CAP_CMD_REJECT_REASON_MTU_EXCEEDED,
 								&sigMtu, sizeof(sigMtu));
 		pRspPdu->Hdr.Len = outLen;

--- a/tests/bluetooth/host/Makefile
+++ b/tests/bluetooth/host/Makefile
@@ -1,203 +1,191 @@
 ROOT := ../../..
 BUILD_DIR := build
-ADV_TARGET := $(BUILD_DIR)/bt_adv_uuid_test
-HCI_TARGET := $(BUILD_DIR)/bt_hci_flow_test
-HCI_CTLR_TARGET := $(BUILD_DIR)/bt_hci_ctlr_init_test
-L2CAP_TARGET := $(BUILD_DIR)/bt_l2cap_signal_test
-ATT_TARGET := $(BUILD_DIR)/bt_att_db_test
-ATT_REQ_TARGET := $(BUILD_DIR)/bt_att_req_test
-PEER_TARGET := $(BUILD_DIR)/bt_peer_pool_test
-GAP_HCI_TARGET := $(BUILD_DIR)/bt_gap_hci_test
-ADV_HCI_TARGET := $(BUILD_DIR)/bt_adv_hci_test
-GATT_CCCD_TARGET := $(BUILD_DIR)/bt_gatt_cccd_test
-GATT_SRVC_TARGET := $(BUILD_DIR)/bt_gatt_srvc_test
-APP_ML_TARGET := $(BUILD_DIR)/bt_app_multilink_test
-SYSLOG_TARGET := $(BUILD_DIR)/syslog_tx_test
-GATT_TXC_TARGET := $(BUILD_DIR)/bt_gatt_txcomplete_test
-CFIFO_OBJ := $(BUILD_DIR)/cfifo.o
 
 CC ?= gcc
 CXX ?= g++
-CPPFLAGS += -I$(ROOT)/include
-CFLAGS ?= -O1 -g
+OPT ?= -O1
+
+CPPFLAGS += -I$(ROOT)/include -I.
+CFLAGS ?= $(OPT) -g
 CFLAGS += -std=gnu11 -Wall -Wextra -fno-omit-frame-pointer \
-	-ffunction-sections -fdata-sections
-# C++23 is spelled gnu++23 by gcc and recent clang, gnu++2b by older Apple
-# clang. Probe what this compiler accepts rather than hardcoding one form.
+	-ffunction-sections -fdata-sections -fstack-protector-strong
+
 CXXSTD := $(shell for s in gnu++23 gnu++2b gnu++20; do \
 	if $(CXX) -std=$$s -x c++ -fsyntax-only /dev/null >/dev/null 2>&1; then \
 		echo $$s; break; fi; done)
-CXXFLAGS ?= -O1 -g
+CXXFLAGS ?= $(OPT) -g
 CXXFLAGS += -std=$(CXXSTD) -Wall -Wextra -fno-omit-frame-pointer \
-	-ffunction-sections -fdata-sections
-# Dead-strip unused sections so a target that pulls in a .cpp but exercises only
-# part of it does not have to satisfy every symbol the unused code references
-# (for example the CFifo calls in bt_hci_ctlr.cpp). The GNU and Apple linkers
-# spell this differently; select by host OS.
-ifeq ($(shell uname -s),Darwin)
+	-ffunction-sections -fdata-sections -fstack-protector-strong \
+	-D_GLIBCXX_ASSERTIONS
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
 LDFLAGS += -Wl,-dead_strip
+ASAN_RUNTIME_OPTIONS := detect_leaks=0:strict_string_checks=1
 else
 LDFLAGS += -Wl,--gc-sections
+ASAN_RUNTIME_OPTIONS := detect_leaks=1:strict_string_checks=1
 endif
-# no-sanitize-recover makes any UBSan finding abort the test run, so a suite
-# cannot print PASS after undefined behavior scrolled by above it.
-SANITIZERS ?= -fsanitize=address,undefined -fno-sanitize-recover=all
 
-# Headers are prerequisites too. Without them a change to an inline function in
-# a header leaves every binary up to date and the suite reruns the old code.
-# Only the directories the suites include from, and not include/*.h as a whole:
-# one file there has a space in its name, which make cannot express in a
-# prerequisite list.
+SANITIZERS ?= -fsanitize=address,undefined -fno-sanitize-recover=all
+TEST_ENV := ASAN_OPTIONS=$(ASAN_RUNTIME_OPTIONS) \
+	UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
+
 HEADERS := $(wildcard $(ROOT)/include/bluetooth/*.h) \
 	$(ROOT)/include/istddef.h \
 	$(ROOT)/include/device_intrf.h \
 	$(ROOT)/include/cfifo.h \
-	$(ROOT)/include/syslog.h
+	$(ROOT)/include/syslog.h \
+	bt_test_harness.h
 
-ADV_SOURCES := \
+TEST_NAMES := \
+	bt_adv_uuid_test \
+	bt_hci_flow_test \
+	bt_hci_ctlr_init_test \
+	bt_l2cap_signal_test \
+	bt_att_db_test \
+	bt_att_req_test \
+	bt_peer_pool_test \
+	bt_gap_hci_test \
+	bt_adv_hci_test \
+	bt_gatt_cccd_test \
+	bt_gatt_srvc_test \
+	bt_app_multilink_test \
+	syslog_tx_test \
+	bt_gatt_txcomplete_test \
+	bt_att_adversarial_test \
+	bt_gatt_adversarial_test \
+	bt_hci_adversarial_test \
+	bt_l2cap_adversarial_test \
+	bt_app_adversarial_test
+
+TARGETS := $(addprefix $(BUILD_DIR)/,$(TEST_NAMES))
+CFIFO_OBJ := $(BUILD_DIR)/cfifo.o
+
+bt_adv_uuid_test_SOURCES := \
 	bt_adv_uuid_test.cpp \
 	$(ROOT)/src/bluetooth/bt_adv.cpp \
 	$(ROOT)/src/bluetooth/bt_uuid.cpp
 
-HCI_SOURCES := \
+bt_hci_flow_test_SOURCES := \
 	bt_hci_flow_test.cpp \
 	$(ROOT)/src/bluetooth/bt_hci_host.cpp \
 	$(ROOT)/src/bluetooth/bt_hci_ctlr.cpp
 
-HCI_CTLR_SOURCES := \
+bt_hci_ctlr_init_test_SOURCES := \
 	bt_hci_ctlr_init_test.cpp \
 	$(ROOT)/src/bluetooth/bt_hci_ctlr.cpp
+bt_hci_ctlr_init_test_EXTRA := $(CFIFO_OBJ)
 
-L2CAP_SOURCES := \
+bt_l2cap_signal_test_SOURCES := \
 	bt_l2cap_signal_test.cpp \
 	$(ROOT)/src/bluetooth/bt_l2cap.cpp
 
-ATT_SOURCES := \
+bt_att_db_test_SOURCES := \
 	bt_att_db_test.cpp \
 	$(ROOT)/src/bluetooth/bt_att.cpp
 
-ATT_REQ_SOURCES := \
+bt_att_req_test_SOURCES := \
 	bt_att_req_test.cpp \
 	$(ROOT)/src/bluetooth/bt_att.cpp \
 	$(ROOT)/src/bluetooth/bt_uuid.cpp
 
-PEER_SOURCES := \
+bt_peer_pool_test_SOURCES := \
 	bt_peer_pool_test.cpp \
 	$(ROOT)/src/bluetooth/bt_peer.cpp
 
-GAP_HCI_SOURCES := \
+bt_gap_hci_test_SOURCES := \
 	bt_gap_hci_test.cpp \
 	$(ROOT)/src/bluetooth/bt_gap_hci.cpp
 
-ADV_HCI_SOURCES := \
+bt_adv_hci_test_SOURCES := \
 	bt_adv_hci_test.cpp \
 	$(ROOT)/src/bluetooth/bt_adv_hci.cpp \
 	$(ROOT)/src/bluetooth/bt_adv.cpp \
 	$(ROOT)/src/bluetooth/bt_uuid.cpp
 
-GATT_CCCD_SOURCES := \
+bt_gatt_cccd_test_SOURCES := \
 	bt_gatt_cccd_test.cpp \
 	$(ROOT)/src/bluetooth/bt_gatt.cpp
 
-GATT_SRVC_SOURCES := \
+bt_gatt_txcomplete_test_SOURCES := \
+	bt_gatt_txcomplete_test.cpp \
+	$(ROOT)/src/bluetooth/bt_gatt.cpp \
+	$(ROOT)/src/bluetooth/bt_peer.cpp
+
+bt_gatt_srvc_test_SOURCES := \
 	bt_gatt_srvc_test.cpp \
 	$(ROOT)/src/bluetooth/bt_gatt.cpp \
 	$(ROOT)/src/bluetooth/bt_att.cpp \
 	$(ROOT)/src/bluetooth/bt_uuid.cpp
 
-APP_ML_SOURCES := \
+bt_app_multilink_test_SOURCES := \
 	bt_app_multilink_test.cpp \
 	$(ROOT)/src/bluetooth/bt_app.cpp
 
-GATT_TXC_SOURCES := \
-	bt_gatt_txcomplete_test.cpp \
-	$(ROOT)/src/bluetooth/bt_gatt.cpp \
-	$(ROOT)/src/bluetooth/bt_peer.cpp
-
-SYSLOG_SOURCES := \
+syslog_tx_test_SOURCES := \
 	syslog_tx_test.cpp \
 	$(ROOT)/src/syslog.cpp \
 	$(ROOT)/src/device_intrf.cpp
 
-.PHONY: all test clean
+bt_att_adversarial_test_SOURCES := \
+	bt_att_adversarial_test.cpp \
+	$(ROOT)/src/bluetooth/bt_att.cpp \
+	$(ROOT)/src/bluetooth/bt_uuid.cpp
+
+bt_gatt_adversarial_test_SOURCES := \
+	bt_gatt_adversarial_test.cpp \
+	$(ROOT)/src/bluetooth/bt_gatt.cpp \
+	$(ROOT)/src/bluetooth/bt_att.cpp \
+	$(ROOT)/src/bluetooth/bt_uuid.cpp
+
+bt_hci_adversarial_test_SOURCES := \
+	bt_hci_adversarial_test.cpp \
+	$(ROOT)/src/bluetooth/bt_hci_host.cpp \
+	$(ROOT)/src/bluetooth/bt_hci_ctlr.cpp
+
+bt_l2cap_adversarial_test_SOURCES := \
+	bt_l2cap_adversarial_test.cpp \
+	$(ROOT)/src/bluetooth/bt_l2cap.cpp
+
+bt_app_adversarial_test_SOURCES := \
+	bt_app_adversarial_test.cpp \
+	$(ROOT)/src/bluetooth/bt_app.cpp
+
+.PHONY: all test test-gcc test-clang test-matrix clean
 
 all: test
 
-test: $(ADV_TARGET) $(HCI_TARGET) $(HCI_CTLR_TARGET) $(L2CAP_TARGET) $(ATT_TARGET) $(ATT_REQ_TARGET) $(PEER_TARGET) $(GAP_HCI_TARGET) $(ADV_HCI_TARGET) $(GATT_CCCD_TARGET) $(GATT_SRVC_TARGET) $(APP_ML_TARGET) $(SYSLOG_TARGET) $(GATT_TXC_TARGET)
-	./$(ADV_TARGET)
-	./$(HCI_TARGET)
-	./$(HCI_CTLR_TARGET)
-	./$(L2CAP_TARGET)
-	./$(ATT_TARGET)
-	./$(ATT_REQ_TARGET)
-	./$(PEER_TARGET)
-	./$(GAP_HCI_TARGET)
-	./$(ADV_HCI_TARGET)
-	./$(GATT_CCCD_TARGET)
-	./$(GATT_SRVC_TARGET)
-	./$(APP_ML_TARGET)
-	./$(SYSLOG_TARGET)
-	./$(GATT_TXC_TARGET)
+test: $(TARGETS)
+	@set -e; \
+	for target in $(TARGETS); do \
+		echo "RUN $$target"; \
+		$(TEST_ENV) ./$$target; \
+	done
 
-$(ADV_TARGET): $(ADV_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(ADV_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
+test-gcc:
+	$(MAKE) clean
+	$(MAKE) test CC=gcc CXX=g++
 
-$(HCI_TARGET): $(HCI_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(HCI_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
+test-clang:
+	$(MAKE) clean
+	$(MAKE) test CC=clang CXX=clang++
 
-$(CFIFO_OBJ): $(ROOT)/src/cfifo.c
+test-matrix: test-gcc test-clang
+
+$(CFIFO_OBJ): $(ROOT)/src/cfifo.c $(HEADERS)
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(SANITIZERS) -c $< -o $@
 
-$(HCI_CTLR_TARGET): $(HCI_CTLR_SOURCES) $(CFIFO_OBJ) $(HEADERS)
+define BUILD_TEST
+$(BUILD_DIR)/$(1): $$($(1)_SOURCES) $$($(1)_EXTRA) $(HEADERS)
 	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(HCI_CTLR_SOURCES) $(CFIFO_OBJ) -o $@ $(LDFLAGS) $(SANITIZERS)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) \
+		$$($(1)_SOURCES) $$($(1)_EXTRA) -o $$@ \
+		$(LDFLAGS) $(SANITIZERS)
+endef
 
-$(L2CAP_TARGET): $(L2CAP_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(L2CAP_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(ATT_TARGET): $(ATT_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(ATT_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(ATT_REQ_TARGET): $(ATT_REQ_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(ATT_REQ_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(PEER_TARGET): $(PEER_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(PEER_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(GAP_HCI_TARGET): $(GAP_HCI_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(GAP_HCI_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(ADV_HCI_TARGET): $(ADV_HCI_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(ADV_HCI_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(GATT_CCCD_TARGET): $(GATT_CCCD_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(GATT_CCCD_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(GATT_SRVC_TARGET): $(GATT_SRVC_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(GATT_SRVC_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(APP_ML_TARGET): $(APP_ML_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(APP_ML_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
-
-$(SYSLOG_TARGET): $(SYSLOG_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(SYSLOG_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)
+$(foreach test,$(TEST_NAMES),$(eval $(call BUILD_TEST,$(test))))
 
 clean:
 	rm -rf $(BUILD_DIR)
-
-$(GATT_TXC_TARGET): $(GATT_TXC_SOURCES) $(HEADERS)
-	@mkdir -p $(BUILD_DIR)
-	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) $(GATT_TXC_SOURCES) -o $@ $(LDFLAGS) $(SANITIZERS)

--- a/tests/bluetooth/host/bt_app_adversarial_test.cpp
+++ b/tests/bluetooth/host/bt_app_adversarial_test.cpp
@@ -90,6 +90,30 @@ void TestZeroLengthValueReplacesStoredValue()
 
 extern "C" {
 
+// The All forms walk the peer pool rather than copying handles into a fixed
+// local array, so the stub pool has to expose slots.
+BtDevice_t *BtPeerSlot(uint16_t Idx)
+{
+	static BtDevice_t s_Slots[kLinkCount];
+	static bool s_Init = false;
+
+	if (s_Init == false)
+	{
+		for (size_t i = 0; i < kLinkCount; i++)
+		{
+			s_Slots[i].Conn.Hdl = s_Links[i];
+		}
+		s_Init = true;
+	}
+
+	return Idx < kLinkCount ? &s_Slots[Idx] : nullptr;
+}
+
+uint16_t BtPeerCount(void)
+{
+	return (uint16_t)kLinkCount;
+}
+
 size_t BtPeerGetConnectedHandles(uint16_t *pHdl, size_t MaxCount)
 {
 	size_t count = kLinkCount < MaxCount ? kLinkCount : MaxCount;

--- a/tests/bluetooth/host/bt_app_multilink_test.cpp
+++ b/tests/bluetooth/host/bt_app_multilink_test.cpp
@@ -74,6 +74,25 @@ void SetLinks(const uint16_t *pHdl, size_t Count)
 // under test rather than the GATT send itself.
 extern "C" {
 
+BtDevice_t *BtPeerSlot(uint16_t Idx)
+{
+	static BtDevice_t s_Slots[8];
+
+	if (Idx >= s_LinkCount)
+	{
+		return nullptr;
+	}
+
+	s_Slots[Idx].Conn.Hdl = s_Links[Idx];
+
+	return &s_Slots[Idx];
+}
+
+uint16_t BtPeerCount(void)
+{
+	return (uint16_t)s_LinkCount;
+}
+
 size_t BtPeerGetConnectedHandles(uint16_t *pHdl, size_t MaxCount)
 {
 	size_t n = s_LinkCount < MaxCount ? s_LinkCount : MaxCount;

--- a/tests/bluetooth/host/bt_gatt_adversarial_test.cpp
+++ b/tests/bluetooth/host/bt_gatt_adversarial_test.cpp
@@ -153,8 +153,12 @@ void TestMixedPacketCompletionOrdering()
 	s_Peer.TxPendCount = 0;
 	s_TxCompleteCount = 0;
 
+	// An ATT response goes out on this link. It owns no GATT completion, so
+	// the layer that sent it reports the packet; bt_hci_host.cpp does this
+	// for real, and the stub below only counts.
 	BtHciACLDataPacket_t untracked = {};
 	BT_CHECK(s_Test, BtHciSendAcl(&s_Hci, &untracked) != 0);
+	BtGattTxPendUntracked(kConnHdl, 1);
 
 	BtGattTxPendingAdd(kConnHdl, &s_SubChar);
 	BT_CHECK(s_Test, s_Peer.TxPendCount == 1);
@@ -174,7 +178,10 @@ void TestFragmentCompletionWaitsForFinalPacket()
 	s_Peer.TxPendCount = 0;
 	s_TxCompleteCount = 0;
 
-	BtGattTxPendingAdd(kConnHdl, &s_SubChar);
+	// One notification that the transport split into three ACL packets. The
+	// send path derives the count from the PDU size and the controller's ACL
+	// length; here it is stated directly.
+	BT_CHECK(s_Test, BtGattTxPendReserve(kConnHdl, &s_SubChar, 3));
 	BT_CHECK(s_Test, s_Peer.TxPendCount == 1);
 
 	BtGattSendCompleted(kConnHdl, 1);

--- a/tests/bluetooth/host/bt_gatt_txcomplete_test.cpp
+++ b/tests/bluetooth/host/bt_gatt_txcomplete_test.cpp
@@ -118,12 +118,15 @@ void TestUntrackedPacketDoesNotFire()
 {
 	Setup(64);
 
-	// An ATT response goes out first: one packet, no owner.
+	// An ATT response goes out first: one packet, no owner. Foreign packets
+	// are counted, not given ring entries, so ordinary request and response
+	// traffic cannot exhaust the ring and refuse a notification.
 	BtGattTxPendUntracked(kConnHdl, 1);
-	CHECK(Peer()->TxPendCount == 1);
+	CHECK(Peer()->TxPendCount == 0);
+	CHECK(Peer()->TxUntracked == 1);
 
 	CHECK(BtGattCharNotify(kConnHdl, &s_Char[0], s_Value, 8));
-	CHECK(Peer()->TxPendCount == 2);
+	CHECK(Peer()->TxPendCount == 1);
 
 	// The controller reports the response. The notification is still in
 	// flight, so nothing fires and its entry stays.
@@ -137,8 +140,7 @@ void TestUntrackedPacketDoesNotFire()
 	CHECK(Peer()->TxPendCount == 0);
 }
 
-// Consecutive packets with no owner share one entry, so request and response
-// traffic does not consume the ring.
+// Packets with no owner accumulate in the counter, never in the ring.
 void TestUntrackedCoalesces()
 {
 	Setup(64);
@@ -146,10 +148,11 @@ void TestUntrackedCoalesces()
 	BtGattTxPendUntracked(kConnHdl, 1);
 	BtGattTxPendUntracked(kConnHdl, 1);
 	BtGattTxPendUntracked(kConnHdl, 1);
-	CHECK(Peer()->TxPendCount == 1);
+	CHECK(Peer()->TxPendCount == 0);
+	CHECK(Peer()->TxUntracked == 3);
 
 	CHECK(BtGattCharNotify(kConnHdl, &s_Char[0], s_Value, 8));
-	CHECK(Peer()->TxPendCount == 2);
+	CHECK(Peer()->TxPendCount == 1);
 
 	BtGattSendCompleted(kConnHdl, 3);
 	CHECK(s_TxCompleteCount == 0);
@@ -261,7 +264,8 @@ void TestSendOrderPreserved()
 	CHECK(BtGattCharNotify(kConnHdl, &s_Char[0], s_Value, 8));
 	BtGattTxPendUntracked(kConnHdl, 2);
 	CHECK(BtGattCharNotify(kConnHdl, &s_Char[1], s_Value, 8));
-	CHECK(Peer()->TxPendCount == 3);
+	CHECK(Peer()->TxPendCount == 2);
+	CHECK(Peer()->TxUntracked == 2);
 
 	// One report covering everything drains the groups in send order and
 	// fires exactly the two notifications.

--- a/tests/bluetooth/host/bt_hci_adversarial_test.cpp
+++ b/tests/bluetooth/host/bt_hci_adversarial_test.cpp
@@ -49,10 +49,15 @@ void TestCompletedEventNeedsCountByte()
 	dev.SendCompleted = Completed;
 	s_CompletedCount = 0;
 
-	alignas(4) std::array<uint8_t, sizeof(BtHciEvtPacketHdr_t)> raw = {};
+	// The storage is a whole BtHciEvtPacket_t: casting a smaller buffer to it
+	// and touching a member is undefined on its own, which is a defect in the
+	// test rather than in the code under test. Hdr.Len is what says the event
+	// is truncated, and that is what the parser has to honour.
+	alignas(4) std::array<uint8_t, sizeof(BtHciEvtPacket_t)> raw = {};
 	BtHciEvtPacket_t *pEvt = (BtHciEvtPacket_t *)raw.data();
 	pEvt->Hdr.Evt = BT_HCI_EVT_NB_COMPLETED_PACKET;
 	pEvt->Hdr.Len = 0;
+	pEvt->Data[0] = 0xFF;			// a count the parser must not read
 
 	BtHciProcessEvent(&dev, pEvt);
 	BT_CHECK(s_Test, s_CompletedCount == 0);
@@ -64,12 +69,16 @@ void TestLegacyAdvEventNeedsCountByte()
 	dev.ScanReport = ScanReport;
 	s_ScanCount = 0;
 
+	// Room for the subevent byte and the count byte after it; Hdr.Len says
+	// only the subevent byte is present, so the count byte is outside the
+	// event even though it is inside the allocation.
 	alignas(4) std::array<uint8_t,
-			sizeof(BtHciEvtPacketHdr_t) + 1> raw = {};
+			sizeof(BtHciEvtPacket_t) + 1> raw = {};
 	BtHciEvtPacket_t *pEvt = (BtHciEvtPacket_t *)raw.data();
 	pEvt->Hdr.Evt = BT_HCI_EVT_LE;
 	pEvt->Hdr.Len = 1;
 	pEvt->Data[0] = BT_HCI_EVT_LE_ADV_REPORT;
+	pEvt->Data[1] = 0xFF;			// a count the parser must not read
 
 	BtHciProcessEvent(&dev, pEvt);
 	BT_CHECK(s_Test, s_ScanCount == 0);
@@ -82,11 +91,12 @@ void TestExtendedAdvEventNeedsCountByte()
 	s_ScanCount = 0;
 
 	alignas(4) std::array<uint8_t,
-			sizeof(BtHciEvtPacketHdr_t) + 1> raw = {};
+			sizeof(BtHciEvtPacket_t) + 1> raw = {};
 	BtHciEvtPacket_t *pEvt = (BtHciEvtPacket_t *)raw.data();
 	pEvt->Hdr.Evt = BT_HCI_EVT_LE;
 	pEvt->Hdr.Len = 1;
 	pEvt->Data[0] = BT_HCI_EVT_LE_EXT_ADV_REPORT;
+	pEvt->Data[1] = 0xFF;			// a count the parser must not read
 
 	BtHciProcessEvent(&dev, pEvt);
 	BT_CHECK(s_Test, s_ScanCount == 0);
@@ -97,7 +107,7 @@ void FeedExtAdv(BtHciDevice_t *pDev, const uint8_t Addr[6],
 				const uint8_t *pData, uint8_t DataLen)
 {
 	alignas(4) std::array<uint8_t,
-			sizeof(BtHciEvtPacketHdr_t) + 1 + 1 + 24 + 32> raw = {};
+			sizeof(BtHciEvtPacket_t) + 1 + 1 + 24 + 32> raw = {};
 	BtHciEvtPacket_t *pEvt = (BtHciEvtPacket_t *)raw.data();
 	pEvt->Hdr.Evt = BT_HCI_EVT_LE;
 	pEvt->Hdr.Len = (uint8_t)(1 + 1 + 24 + DataLen);


### PR DESCRIPTION
Temporary synchronization PR so the compliance foundation validates against the current bt_conformance head without overwriting the newly completed Bluetooth fixes.