### PR TITLE
sync bt_conformance into dual-host repair branch

### DIFF
--- a/.github/workflows/bluetooth-host-tests.yml
+++ b/.github/workflows/bluetooth-host-tests.yml
@@ -55,5 +55,6 @@ jobs:
       - name: Build and run Bluetooth compliance tests
         run: |
           make -C tests/bluetooth/compliance clean test \
+            CC=${{ matrix.cc }} \
             CXX=${{ matrix.cxx }} \
             OPT=${{ matrix.opt }}

--- a/exemples/bluetooth/uart_ble.cpp
+++ b/exemples/bluetooth/uart_ble.cpp
@@ -36,6 +36,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------------*/
 
+#include <string.h>
+
 #include "istddef.h"
 #include "bluetooth/bt_app.h"
 #include "bluetooth/bt_gatt.h"
@@ -251,7 +253,7 @@ static int s_NbButPins = sizeof(s_ButPins) / sizeof(IOPinCfg_t);
 
 int g_DelayCnt = 0;
 volatile bool g_bUartState = false;
-#if BLE_SC_METHOD == BLE_SC_OOB
+#if BLE_SC_METHOD != BLE_SC_NONE
 static volatile bool s_OobRefreshPending = false;
 #endif
 #if BLE_SC_METHOD != BLE_SC_NONE
@@ -295,7 +297,7 @@ const UARTCfg_t g_UartCfg = {
 /// UART object instance
 UART g_Uart;
 
-#if BLE_SC_METHOD == BLE_SC_OOB
+#if BLE_SC_METHOD != BLE_SC_NONE
 static bool s_UartBlePeerOobValid = false;
 
 #ifdef BLE_SC_OOB_NFC
@@ -390,6 +392,96 @@ static void UartBleOobNfcPublish(const uint8_t *pRand, const uint8_t *pConf)
 	g_Uart.printf("OOB data published on NFC tag, tap to pair\r\n");
 }
 #endif
+
+// Runtime association-model selection.
+//
+// BLE_SC_METHOD is the boot default; the console "sec" command switches the
+// method for the next pairing without a rebuild, so one binary covers the whole
+// matrix instead of one build per cell. BtSmpAuthConfig only assigns the local
+// IO capability and the authentication requirements, and those two plus whether
+// OOB data is present are what choose the model at pairing time, so calling it
+// between connections is enough. SecType in the app config stays as built: it
+// arms security and bonding, it does not pick the model.
+typedef struct {
+	const char *pName;			// console keyword
+	uint8_t     IoCaps;			// BT_SMP_IOCAPS_*
+	uint8_t     AuthReq;		// bonding / MITM, SC is forced by BtSmpAuthConfig
+	const char *pDesc;
+} UartBleSecMethod_t;
+
+static const UartBleSecMethod_t s_SecMethods[] = {
+	{ "justworks",		BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING,
+	  "Just Works (bonded, no MITM)" },
+	{ "numcomp",		BT_SMP_IOCAPS_DISPLAY_YESNO,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Numeric Comparison" },
+	{ "passkey-disp",	BT_SMP_IOCAPS_DISPLAY_ONLY,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Passkey Entry (display)" },
+	{ "passkey-input",	BT_SMP_IOCAPS_KEYBOARD_ONLY,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Passkey Entry (keyboard)" },
+	{ "oob",			BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "LESC OOB" },
+};
+
+#define UART_BLE_SEC_METHOD_CNT		(int)(sizeof(s_SecMethods) / sizeof(s_SecMethods[0]))
+
+static int s_SecMethodIdx = 0;
+
+static bool UartBleSecIsOob(void)
+{
+	return strcmp(s_SecMethods[s_SecMethodIdx].pName, "oob") == 0;
+}
+
+// One line, fixed field order, so a host script can parse it. Printed on every
+// change and on a bare "sec".
+static void UartBleSecPrint(void)
+{
+	const UartBleSecMethod_t *m = &s_SecMethods[s_SecMethodIdx];
+
+	g_Uart.printf("SEC method=%s iocaps=%d authreq=0x%02x desc=%s\r\n",
+				  m->pName, m->IoCaps, m->AuthReq, m->pDesc);
+}
+
+static void UartBleSecApply(int Idx)
+{
+	if (Idx < 0 || Idx >= UART_BLE_SEC_METHOD_CNT)
+	{
+		return;
+	}
+
+	s_SecMethodIdx = Idx;
+	BtSmpAuthConfig(s_SecMethods[Idx].IoCaps, s_SecMethods[Idx].AuthReq);
+	UartBleSecPrint();
+}
+
+// Select the entry whose IO capability and MITM setting match what this build
+// was configured with, so the boot default and BLE_SC_METHOD agree.
+static void UartBleSecInit(void)
+{
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		if (s_SecMethods[i].IoCaps == BLE_SC_IOCAPS &&
+			s_SecMethods[i].AuthReq == (BLE_SC_AUTHREQ))
+		{
+#if BLE_SC_METHOD == BLE_SC_OOB
+			// Just Works and OOB share NoInputNoOutput; take the OOB row.
+			if (strcmp(s_SecMethods[i].pName, "oob") != 0)
+			{
+				continue;
+			}
+#endif
+			s_SecMethodIdx = i;
+			break;
+		}
+	}
+
+	BtSmpAuthConfig(s_SecMethods[s_SecMethodIdx].IoCaps,
+					s_SecMethods[s_SecMethodIdx].AuthReq);
+}
 
 static int UartBleHexVal(uint8_t c)
 {
@@ -493,8 +585,75 @@ static bool UartBleOobSetPeer(const uint8_t *pText, int Len)
 
 static void UartBleOobInit(void)
 {
-	UartBleOobPrintLocal();
-	g_Uart.printf("Enter peer data before pairing. Commands: oob, oob peer <hex>\r\n");
+	UartBleSecPrint();
+
+	// The local set is only needed for the OOB model, and generating it costs a
+	// P-256 key pair, so a build that boots into another method does not pay
+	// for it. "sec oob" prints it when the method is selected.
+	if (UartBleSecIsOob())
+	{
+		UartBleOobPrintLocal();
+	}
+
+	g_Uart.printf("Commands: sec [method], oob, oob peer <hex>, bond del\r\n");
+}
+
+// "sec" prints the current method, "sec <name>" selects one for the next
+// pairing. Selecting OOB prints the local data set, since that is the point at
+// which the operator needs it.
+static bool UartBleSecTryCommand(const uint8_t *pData, int Len)
+{
+	if (Len < 3 || memcmp(pData, "sec", 3) != 0)
+	{
+		return false;
+	}
+
+	const uint8_t *p = pData + 3;
+	int l = Len - 3;
+
+	while (l > 0 && (*p == ' ' || *p == '\t'))
+	{
+		p++;
+		l--;
+	}
+
+	if (l <= 0 || *p == '\r' || *p == '\n')
+	{
+		UartBleSecPrint();
+		return true;
+	}
+
+	// Trim the line ending before the compare, the console sends CR or LF.
+	while (l > 0 && (p[l - 1] == '\r' || p[l - 1] == '\n' || p[l - 1] == ' '))
+	{
+		l--;
+	}
+
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		int nl = (int)strlen(s_SecMethods[i].pName);
+
+		if (nl == l && memcmp(p, s_SecMethods[i].pName, nl) == 0)
+		{
+			UartBleSecApply(i);
+
+			if (UartBleSecIsOob())
+			{
+				UartBleOobPrintLocal();
+			}
+
+			return true;
+		}
+	}
+
+	g_Uart.printf("SEC unknown, one of:");
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		g_Uart.printf(" %s", s_SecMethods[i].pName);
+	}
+	g_Uart.printf("\r\n");
+
+	return true;
 }
 
 static bool UartBleOobTryCommand(const uint8_t *pData, int Len)
@@ -544,6 +703,11 @@ void UartRxChedHandler(uint32_t Evt, void *pCtx);
 
 static void UartBleOobRefresh(void)
 {
+	if (UartBleSecIsOob() == false)
+	{
+		return;			// nothing was consumed, nothing to replace
+	}
+
 	BtSmpOobDataClear();
 	s_UartBlePeerOobValid = false;
 	UartBleOobPrintLocal();
@@ -560,6 +724,12 @@ void BtAppEvtSecured(uint16_t ConnHdl)
 #else
 static void UartBleOobInit(void) {}
 static bool UartBleOobTryCommand(const uint8_t *pData, int Len)
+{
+	(void)pData;
+	(void)Len;
+	return false;
+}
+static bool UartBleSecTryCommand(const uint8_t *pData, int Len)
 {
 	(void)pData;
 	(void)Len;
@@ -703,9 +873,10 @@ void HardwareInit()
 void BtAppInitUserData()
 {
 #if BLE_SC_METHOD != BLE_SC_NONE
-	// Set the local IO capability so the SMP core negotiates the selected
-	// method; the console then fills whatever role that capability implies.
-	BtSmpAuthConfig(BLE_SC_IOCAPS, BLE_SC_AUTHREQ);
+	// Boot default from BLE_SC_METHOD, then the console "sec" command can move
+	// to any other model without a rebuild. The console fills whatever role the
+	// selected IO capability implies.
+	UartBleSecInit();
 #endif
 }
 
@@ -796,7 +967,7 @@ static bool PairInputPoll(void)
 //void UartRxChedHandler(void * p_event_data, uint16_t event_size)
 void UartRxChedHandler(uint32_t Evt, void *pCtx)
 {
-#if BLE_SC_METHOD == BLE_SC_OOB
+#if BLE_SC_METHOD != BLE_SC_NONE
 	if (s_OobRefreshPending)
 	{
 		s_OobRefreshPending = false;
@@ -816,10 +987,26 @@ void UartRxChedHandler(uint32_t Evt, void *pCtx)
 	int l = g_Uart.Rx(&buff[bufflen], PACKET_SIZE - bufflen);
 	if (l > 0)
 	{
+		int start = bufflen;
+
 		bufflen += l;
 		if (bufflen >= PACKET_SIZE)
 		{
 			flush = true;
+		}
+
+		// A console line ends at CR or LF, and a command is far shorter than
+		// PACKET_SIZE. Without this the only ways out were a full 20 byte
+		// buffer or an RX timeout, so "sec" and "bond del" sat in the buffer
+		// and looked like they did nothing, while a pasted OOB line worked
+		// because it is long enough to fill the buffer on its own.
+		for (int i = start; i < bufflen; i++)
+		{
+			if (buff[i] == '\r' || buff[i] == '\n')
+			{
+				flush = true;
+				break;
+			}
 		}
 	}
 	else
@@ -831,6 +1018,11 @@ void UartRxChedHandler(uint32_t Evt, void *pCtx)
 	}
 	if (flush)
 	{
+		if (UartBleSecTryCommand(buff, bufflen))
+		{
+			bufflen = 0;
+			return;
+		}
 		if (UartBleOobTryCommand(buff, bufflen))
 		{
 			bufflen = 0;
@@ -847,6 +1039,12 @@ void UartRxChedHandler(uint32_t Evt, void *pCtx)
 			bufflen = 0;
 		}
 		//app_sched_event_put(NULL, 0, UartRxChedHandler);
+		AppEvtHandlerQue(0, 0, UartRxChedHandler);
+	}
+	else if (bufflen > 0)
+	{
+		// Partial line held. Come back rather than waiting for the next UART
+		// event, which for a line the user stopped typing may never arrive.
 		AppEvtHandlerQue(0, 0, UartRxChedHandler);
 	}
 }

--- a/exemples/bluetooth/uart_ble_central.cpp
+++ b/exemples/bluetooth/uart_ble_central.cpp
@@ -36,6 +36,8 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ----------------------------------------------------------------------------*/
 
+#include <string.h>
+
 #include "istddef.h"
 #include "stddev.h"
 #include "idelay.h"
@@ -74,18 +76,35 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BLE_SC_PASSKEY_INPUT	4
 #define BLE_SC_OOB				5
 
+// Must match the row selected in uart_ble.cpp. The two defaults used to
+// disagree, this side OOB and the peer Numeric Comparison, which cannot pair:
+// the models differ, the IO capabilities resolve to Just Works so the MITM both
+// sides ask for cannot be met, and the peer built for Numeric Comparison
+// compiles its OOB console commands out entirely, so the "paste this line on
+// peer" step has nothing to accept it.
 #ifndef BLE_SC_METHOD
-#define BLE_SC_METHOD			BLE_SC_OOB
+#define BLE_SC_METHOD			BLE_SC_NUMCOMP
 #endif
 
 #if BLE_SC_METHOD != BLE_SC_NONE
 #include "bluetooth/bt_smp.h"		// SMP IO caps and console pairing callbacks
-#if BLE_SC_METHOD == BLE_SC_OOB
-#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_OOB
-#else
-#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_KEYBOARD
 #endif
 
+// One row per method, the same table uart_ble.cpp uses. The previous form gave
+// every non-OOB method BTAPP_SECEXCHG_KEYBOARD, which asks the port for a
+// Keyboard Only IO capability and disagrees with BLE_SC_IOCAPS below.
+#if BLE_SC_METHOD == BLE_SC_JUSTWORKS
+#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_NONE
+#elif BLE_SC_METHOD == BLE_SC_NUMCOMP
+#define BLE_SEC_EXCHG			(BTAPP_SECEXCHG_DISPLAY | BTAPP_SECEXCHG_YESNO)
+#elif BLE_SC_METHOD == BLE_SC_PASSKEY_DISP
+#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_DISPLAY
+#elif BLE_SC_METHOD == BLE_SC_PASSKEY_INPUT
+#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_KEYBOARD
+#elif BLE_SC_METHOD == BLE_SC_OOB
+#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_OOB
+#else
+#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_NONE
 #endif
 
 #if BLE_SC_METHOD == BLE_SC_JUSTWORKS
@@ -115,7 +134,6 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #define BLE_SC_NAME				"LESC OOB"
 #else
 #define BLE_SEC_TYPE			BTGAP_SECTYPE_NONE
-#define BLE_SEC_EXCHG			BTAPP_SECEXCHG_NONE
 #define BLE_SC_NAME				"NONE (open link)"
 #endif
 
@@ -137,6 +155,11 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 // UART
 #define BLE_MTU_SIZE			247//byte
 #define PACKET_SIZE				128
+
+// The peer's UART characteristics hold 20 octets (PACKET_SIZE in uart_ble.cpp).
+// A write longer than the attribute can hold is refused, not truncated, so the
+// UART side buffers in PACKET_SIZE chunks but each BLE write is capped here.
+#define BLE_WRITE_MAX			20
 #define UART_MAX_DATA_LEN  		(PACKET_SIZE)
 #define UARTFIFOSIZE			CFIFO_MEMSIZE(UART_MAX_DATA_LEN)
 
@@ -278,7 +301,7 @@ static uint16_t s_PairConnHdl = 0;
 static uint8_t  s_PairDigits = 0;
 static uint32_t s_PairPasskey = 0;
 #endif
-#if BLE_SC_METHOD == BLE_SC_OOB
+#if BLE_SC_METHOD != BLE_SC_NONE
 static bool s_UartBlePeerOobValid = false;
 #endif
 
@@ -329,6 +352,11 @@ void BtAppEvtDisconnected(uint16_t ConnHdl)
 	g_ConnectedDev.Conn.Hdl = BT_CONN_HDL_INVALID;
 	g_BleTxCharHdl = BT_ATT_HANDLE_INVALID;
 	g_BleRxCharHdl = BT_ATT_HANDLE_INVALID;
+
+	// Scanning stopped when the target was found, so without this the central
+	// sits idle after any disconnect, including a failed pairing, and never
+	// looks for the peer again.
+	BtAppScan();
 }
 
 bool BtAppScanReport(int8_t Rssi, uint8_t AddrType, uint8_t Addr[6], size_t AdvLen, uint8_t *pAdvData)
@@ -450,7 +478,7 @@ void BleTxSchedHandler(uint32_t Evt, void *pCtx)
 
 	IOPinToggle(s_Leds[0].PortNo, s_Leds[0].PinNo);
 
-	int len = PACKET_SIZE;
+	int len = BLE_WRITE_MAX;
 	uint8_t *p = CFifoGetMultiple(g_UartRx2BleFifo, &len);
 
 	if (p != NULL)
@@ -545,7 +573,97 @@ static bool PairInputPoll(void)
 }
 #endif
 
+#if BLE_SC_METHOD != BLE_SC_NONE
+// Runtime association-model selection.
+//
+// BLE_SC_METHOD is the boot default; the console "sec" command switches the
+// method for the next pairing without a rebuild, so one binary covers the whole
+// matrix instead of one build per cell. BtSmpAuthConfig only assigns the local
+// IO capability and the authentication requirements, and those two plus whether
+// OOB data is present are what choose the model at pairing time, so calling it
+// between connections is enough. SecType in the app config stays as built: it
+// arms security and bonding, it does not pick the model.
+typedef struct {
+	const char *pName;			// console keyword
+	uint8_t     IoCaps;			// BT_SMP_IOCAPS_*
+	uint8_t     AuthReq;		// bonding / MITM, SC is forced by BtSmpAuthConfig
+	const char *pDesc;
+} UartBleSecMethod_t;
+
+static const UartBleSecMethod_t s_SecMethods[] = {
+	{ "justworks",		BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING,
+	  "Just Works (bonded, no MITM)" },
+	{ "numcomp",		BT_SMP_IOCAPS_DISPLAY_YESNO,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Numeric Comparison" },
+	{ "passkey-disp",	BT_SMP_IOCAPS_DISPLAY_ONLY,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Passkey Entry (display)" },
+	{ "passkey-input",	BT_SMP_IOCAPS_KEYBOARD_ONLY,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "Passkey Entry (keyboard)" },
+	{ "oob",			BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+	  BT_SMP_AUTHREQ_BONDING_FLAG_BONDING | BT_SMP_AUTHREQ_MITM,
+	  "LESC OOB" },
+};
+
+#define UART_BLE_SEC_METHOD_CNT		(int)(sizeof(s_SecMethods) / sizeof(s_SecMethods[0]))
+
+static int s_SecMethodIdx = 0;
+
+static bool UartBleSecIsOob(void)
+{
+	return strcmp(s_SecMethods[s_SecMethodIdx].pName, "oob") == 0;
+}
+
+// One line, fixed field order, so a host script can parse it. Printed on every
+// change and on a bare "sec".
+static void UartBleSecPrint(void)
+{
+	const UartBleSecMethod_t *m = &s_SecMethods[s_SecMethodIdx];
+
+	g_Uart.printf("SEC method=%s iocaps=%d authreq=0x%02x desc=%s\r\n",
+				  m->pName, m->IoCaps, m->AuthReq, m->pDesc);
+}
+
+static void UartBleSecApply(int Idx)
+{
+	if (Idx < 0 || Idx >= UART_BLE_SEC_METHOD_CNT)
+	{
+		return;
+	}
+
+	s_SecMethodIdx = Idx;
+	BtSmpAuthConfig(s_SecMethods[Idx].IoCaps, s_SecMethods[Idx].AuthReq);
+	UartBleSecPrint();
+}
+
+// Select the entry whose IO capability and MITM setting match what this build
+// was configured with, so the boot default and BLE_SC_METHOD agree.
+static void UartBleSecInit(void)
+{
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		if (s_SecMethods[i].IoCaps == BLE_SC_IOCAPS &&
+			s_SecMethods[i].AuthReq == (BLE_SC_AUTHREQ))
+		{
 #if BLE_SC_METHOD == BLE_SC_OOB
+			// Just Works and OOB share NoInputNoOutput; take the OOB row.
+			if (strcmp(s_SecMethods[i].pName, "oob") != 0)
+			{
+				continue;
+			}
+#endif
+			s_SecMethodIdx = i;
+			break;
+		}
+	}
+
+	BtSmpAuthConfig(s_SecMethods[s_SecMethodIdx].IoCaps,
+					s_SecMethods[s_SecMethodIdx].AuthReq);
+}
+
 static int UartBleHexVal(uint8_t c)
 {
 	if (c >= '0' && c <= '9') return c - '0';
@@ -643,9 +761,77 @@ static bool UartBleOobSetPeer(const uint8_t *pText, int Len)
 
 static void UartBleOobInit(void)
 {
-	UartBleOobPrintLocal();
-	g_Uart.printf("Enter peer data before pairing. Commands: oob, oob peer <hex>\r\n");
+	UartBleSecPrint();
+
+	// The local set is only needed for the OOB model, and generating it costs a
+	// P-256 key pair, so a build that boots into another method does not pay
+	// for it. "sec oob" prints it when the method is selected.
+	if (UartBleSecIsOob())
+	{
+		UartBleOobPrintLocal();
+	}
+
+	g_Uart.printf("Commands: sec [method], oob, oob peer <hex>\r\n");
 }
+
+// "sec" prints the current method, "sec <name>" selects one for the next
+// pairing. Selecting OOB prints the local data set, since that is the point at
+// which the operator needs it.
+static bool UartBleSecTryCommand(const uint8_t *pData, int Len)
+{
+	if (Len < 3 || memcmp(pData, "sec", 3) != 0)
+	{
+		return false;
+	}
+
+	const uint8_t *p = pData + 3;
+	int l = Len - 3;
+
+	while (l > 0 && (*p == ' ' || *p == '\t'))
+	{
+		p++;
+		l--;
+	}
+
+	if (l <= 0 || *p == '\r' || *p == '\n')
+	{
+		UartBleSecPrint();
+		return true;
+	}
+
+	// Trim the line ending before the compare, the console sends CR or LF.
+	while (l > 0 && (p[l - 1] == '\r' || p[l - 1] == '\n' || p[l - 1] == ' '))
+	{
+		l--;
+	}
+
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		int nl = (int)strlen(s_SecMethods[i].pName);
+
+		if (nl == l && memcmp(p, s_SecMethods[i].pName, nl) == 0)
+		{
+			UartBleSecApply(i);
+
+			if (UartBleSecIsOob())
+			{
+				UartBleOobPrintLocal();
+			}
+
+			return true;
+		}
+	}
+
+	g_Uart.printf("SEC unknown, one of:");
+	for (int i = 0; i < UART_BLE_SEC_METHOD_CNT; i++)
+	{
+		g_Uart.printf(" %s", s_SecMethods[i].pName);
+	}
+	g_Uart.printf("\r\n");
+
+	return true;
+}
+
 
 static bool UartBleOobTryCommand(const uint8_t *pData, int Len)
 {
@@ -693,6 +879,12 @@ static bool UartBleOobTryCommand(const uint8_t *pData, int Len)
 	(void)Len;
 	return false;
 }
+static bool UartBleSecTryCommand(const uint8_t *pData, int Len)
+{
+	(void)pData;
+	(void)Len;
+	return false;
+}
 #endif
 
 void UartRxSchedHandler(uint32_t Evt, void *pCtx)
@@ -715,10 +907,23 @@ void UartRxSchedHandler(uint32_t Evt, void *pCtx)
 
 	if (l1 > 0)
 	{
+		int start = g_UartRxExtBuffLen;
+
 		g_UartRxExtBuffLen += l1;
 		if (g_UartRxExtBuffLen >= PACKET_SIZE)
 		{
 			flush = true;
+		}
+
+		// A console line ends at CR or LF. Flushing on it makes a short
+		// command act at once instead of waiting for the buffer to fill.
+		for (int i = start; i < g_UartRxExtBuffLen; i++)
+		{
+			if (g_UartRxExtBuff[i] == '\r' || g_UartRxExtBuff[i] == '\n')
+			{
+				flush = true;
+				break;
+			}
 		}
 	}
 	else
@@ -732,6 +937,11 @@ void UartRxSchedHandler(uint32_t Evt, void *pCtx)
 	// Flush data ExternalUartRxBuffer -> g_UartRx2BleFifo
 	if (flush)
 	{
+		if (UartBleSecTryCommand(g_UartRxExtBuff, g_UartRxExtBuffLen))
+		{
+			g_UartRxExtBuffLen = 0;
+			return;
+		}
 		if (UartBleOobTryCommand(g_UartRxExtBuff, g_UartRxExtBuffLen))
 		{
 			g_UartRxExtBuffLen = 0;
@@ -837,11 +1047,19 @@ int main()
 {
 	HardwareInit();
 
-	BtAppInit(&s_BleAppCfg);
+	if (!BtAppInit(&s_BleAppCfg))
+	{
+		g_Uart.printf("BtAppInit failed\r\n");
+		while (true)
+		{
+			__NOP();
+		}
+	}
 
 #if BLE_SC_METHOD != BLE_SC_NONE
-	// Local IO capability for the selected method; the console fills the role.
-	BtSmpAuthConfig(BLE_SC_IOCAPS, BLE_SC_AUTHREQ);
+	// Boot default from BLE_SC_METHOD, then the console "sec" command can move
+	// to any other model without a rebuild.
+	UartBleSecInit();
 #endif
 	UartBleOobInit();
 

--- a/src/bluetooth/bt_adv_hci.cpp
+++ b/src/bluetooth/bt_adv_hci.cpp
@@ -34,6 +34,20 @@ Copyright (c) 2022, I-SYST inc., all rights reserved
 #include "bluetooth/bt_smp.h"
 #include "bluetooth/bt_appearance.h"
 
+/******** For DEBUG Trace ************/
+// Define DEBUG_ENABLE to trace advertising state changes for this file. Output
+// goes to the SysLog transport the app configured. A release build defines
+// NDEBUG, which strips the trace regardless.
+//#define DEBUG_ENABLE
+
+#if !defined(NDEBUG) && defined(DEBUG_ENABLE)
+#include "syslog.h"
+#define DEBUG_PRINTF(...)		SysLogPrintf(SysLogGet(), __VA_ARGS__)
+#else
+#define DEBUG_PRINTF(...)
+#endif
+/*******************************/
+
 // --- Packed standard HCI command parameter layouts (Core Vol 4 Part E) ---
 
 #pragma pack(push, 1)
@@ -277,10 +291,20 @@ void BtAppAdvStart()
 	if (g_BtAppData.State == BTAPP_STATE_ADVERTISING)
 		return;
 
-	if (BtAppAdvEnable() == 0)
+	int res = BtAppAdvEnable();
+	if (res == 0)
 	{
 		g_BtAppData.State = BTAPP_STATE_ADVERTISING;
+
+		return;
 	}
+
+	// A refused enable used to leave the device silent with nothing said. The
+	// case that matters is the restart after a disconnect: the application has
+	// no other signal that it stopped being discoverable, and from the outside
+	// it looks like the board died.
+	DEBUG_PRINTF("ADV enable failed, status=0x%02x, not advertising\r\n",
+				 (unsigned)res);
 }
 
 void BtAppAdvStop()

--- a/src/bluetooth/bt_peer.cpp
+++ b/src/bluetooth/bt_peer.cpp
@@ -199,6 +199,14 @@ BtDevice_t * BtPeerAlloc(uint16_t ConnHdl)
 			memset(p, 0, sizeof(*p));
 			p->Conn.Hdl = ConnHdl;
 			p->bIsLocal = false;
+			// BT_CONN_ROLE_CENTRAL is 0, so a zeroed record reads as a central
+			// link rather than as an unset one, and BtPeerRole cannot tell the
+			// two apart. That matters because the SMP and L2CAP role gates
+			// refuse a PDU when the role says central: a record allocated but
+			// not yet filled in by BtPeerConnected would make a peripheral
+			// reject a Pairing Request. Start from UNKNOWN, which both gates
+			// treat as "do not gate".
+			p->Conn.Role = BT_CONN_ROLE_UNKNOWN;
 			// Re-attach this slot's long-write slice (the memset above
 			// cleared it). Slot i always maps to the same slice.
 			if (s_pLongWrPool != nullptr && s_LongWrSlotSize > 0)

--- a/src/bluetooth/bt_smp.cpp
+++ b/src/bluetooth/bt_smp.cpp
@@ -1196,6 +1196,8 @@ static void SmpHandlePairingReq(BtHciDevice_t * const pDev, BtSmpLink_t *pLink,
 	if (pReq->IOCaps > BT_SMP_IOCAPS_KEYBOARD_DISPLAY ||
 		pReq->OOBFlag > BT_SMP_OOB_AUTH_PRESENT)
 	{
+		DEBUG_PRINTF("SMP reject PairingReq, reserved field iocaps=%d oob=%d\r\n",
+				  pReq->IOCaps, pReq->OOBFlag);
 		SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_INVALID_PARAMS);
 		SmpAbortPairing(pLink);
 		return;
@@ -1208,6 +1210,9 @@ static void SmpHandlePairingReq(BtHciDevice_t * const pDev, BtSmpLink_t *pLink,
 	if (pReq->MaxKeySize < BT_SMP_CFG_MIN_ENC_KEY_SIZE ||
 		pReq->MaxKeySize > BT_SMP_MAX_ENC_KEY_SIZE)
 	{
+		DEBUG_PRINTF("SMP reject PairingReq, key size %d outside %d..%d\r\n",
+				  pReq->MaxKeySize, BT_SMP_CFG_MIN_ENC_KEY_SIZE,
+				  BT_SMP_MAX_ENC_KEY_SIZE);
 		SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_ENC_KEY_SIZE);
 		SmpAbortPairing(pLink);
 		return;
@@ -1252,6 +1257,7 @@ static void SmpHandlePairingReq(BtHciDevice_t * const pDev, BtSmpLink_t *pLink,
 	if (pLink->Ctx.bSc && pReq->OOBFlag != BT_SMP_OOB_AUTH_NOT_PRESENT &&
 		!SmpOobLocalReady(pLink))
 	{
+		DEBUG_PRINTF("SMP reject PairingReq, peer claims OOB but no local set\r\n");
 		SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_OOB_NOT_AVAILABLE);
 		SmpAbortPairing(pLink);
 		return;
@@ -1259,6 +1265,7 @@ static void SmpHandlePairingReq(BtHciDevice_t * const pDev, BtSmpLink_t *pLink,
 	pLink->Ctx.Model = SmpSelectModel(pReq->IOCaps, s_SmpIoCaps, mitm, oob);
 	if (pLink->Ctx.Model == BT_SMP_MODEL_OOB && SmpOobCtxLoad(pLink) == false)
 	{
+		DEBUG_PRINTF("SMP reject PairingReq, OOB model but context load failed\r\n");
 		SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_OOB_NOT_AVAILABLE);
 		SmpAbortPairing(pLink);
 		return;
@@ -1446,6 +1453,7 @@ static void SmpHandlePairingRsp(BtHciDevice_t * const pDev, BtSmpLink_t *pLink,
 	pLink->Ctx.Model = SmpSelectModel(s_SmpIoCaps, pRsp->IOCaps, mitm, oob);
 	if (pLink->Ctx.Model == BT_SMP_MODEL_OOB && SmpOobCtxLoad(pLink) == false)
 	{
+		DEBUG_PRINTF("SMP reject PairingReq, OOB model but context load failed\r\n");
 		SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_OOB_NOT_AVAILABLE);
 		SmpAbortPairing(pLink);
 		return;
@@ -2434,6 +2442,8 @@ void BtProcessSmpData(BtHciDevice_t * const pDev, uint16_t ConnHdl,
 
 		if (Len < minLen)
 		{
+			DEBUG_PRINTF("SMP reject short PDU code=0x%02x len=%u need=%u\r\n",
+					  pSmp->Code, (unsigned)Len, (unsigned)minLen);
 			SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_INVALID_PARAMS);
 			return;
 		}
@@ -2485,6 +2495,7 @@ void BtProcessSmpData(BtHciDevice_t * const pDev, uint16_t ConnHdl,
 			// old behavior.
 			if (BtPeerRole(ConnHdl) == BT_CONN_ROLE_CENTRAL)
 			{
+				DEBUG_PRINTF("SMP reject PairingReq, link role is central\r\n");
 				SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_CMD_NOT_SUPPORTED);
 				return;
 			}
@@ -2493,6 +2504,8 @@ void BtProcessSmpData(BtHciDevice_t * const pDev, uint16_t ConnHdl,
 			// (the handler also refuses a re-pair on an encrypted link).
 			if (pLink->Ctx.State != BT_SMP_STATE_IDLE)
 			{
+				DEBUG_PRINTF("SMP reject PairingReq, pairing already at state=%d\r\n",
+						  (int)pLink->Ctx.State);
 				SmpSendFailed(pDev, ConnHdl, BT_SMP_ERR_UNSPECIFIED);
 				return;
 			}

--- a/tests/bluetooth/compliance/Makefile
+++ b/tests/bluetooth/compliance/Makefile
@@ -1,12 +1,21 @@
 ROOT := ../../..
 BUILD_DIR := build
-TARGET := $(BUILD_DIR)/bt_hci_compliance_test
+HCI_TARGET := $(BUILD_DIR)/bt_hci_compliance_test
+SMP_TARGET := $(BUILD_DIR)/bt_smp_dual_host_test
+TARGETS := $(HCI_TARGET) $(SMP_TARGET)
 
 CC ?= gcc
 CXX ?= g++
 OPT ?= -O1
 
-CPPFLAGS += -I$(ROOT)/include -Iframework -Icontroller -Ipeer
+CPPFLAGS += -I$(ROOT)/include -Iframework -Icontroller -Ipeer -Ilink -Ioob
+SMP_CPPFLAGS := $(CPPFLAGS) -include smp/bt_l2cap_test_override.h
+SMP_CORE_DEFINES := -DDEBUG_ENABLE -DBtSmpInit=BtSmpInitReal
+SMP_TEST_RENAMES := \
+	-DBtSmpLocalIrkGet=BtSmpTestLocalIrkGet \
+	-DBtSmpLocalIdRecordSize=BtSmpTestLocalIdRecordSize \
+	-DBtSmpLocalIdSerialize=BtSmpTestLocalIdSerialize \
+	-DBtSmpLocalIdRestore=BtSmpTestLocalIdRestore
 CXXSTD := $(shell for s in gnu++23 gnu++2b gnu++20; do \
 	if $(CXX) -std=$$s -x c++ -fsyntax-only /dev/null >/dev/null 2>&1; then \
 		echo $$s; break; fi; done)
@@ -28,7 +37,7 @@ SANITIZERS ?= -fsanitize=address,undefined -fno-sanitize-recover=all
 TEST_ENV := ASAN_OPTIONS=$(ASAN_RUNTIME_OPTIONS) \
 	UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1
 
-SOURCES := \
+HCI_SOURCES := \
 	hci/bt_hci_compliance_test.cpp \
 	framework/bt_compliance.cpp \
 	framework/bt_virtual_clock.cpp \
@@ -37,11 +46,28 @@ SOURCES := \
 	$(ROOT)/src/bluetooth/bt_hci_host.cpp \
 	$(ROOT)/src/bluetooth/bt_hci_ctlr.cpp
 
+SMP_DIAG_SOURCE := $(BUILD_DIR)/smp/bt_smp_dual_host_diag.cpp
+SMP_TEST_OBJ := $(BUILD_DIR)/smp/bt_smp_dual_host_test.o
+SMP_FRAMEWORK_OBJ := $(BUILD_DIR)/smp/bt_compliance.o
+SMP_CORE_OBJ := $(BUILD_DIR)/smp/bt_smp.o
+SMP_AES_OBJ := $(BUILD_DIR)/smp/crypto_softaes.o
+SMP_DEVICE_OBJ := $(BUILD_DIR)/smp/device.o
+SMP_DEVICE_INTRF_OBJ := $(BUILD_DIR)/smp/device_intrf.o
+SMP_STUB_OBJ := $(BUILD_DIR)/smp/bt_smp_test_stubs.o
+SMP_OBJECTS := $(SMP_TEST_OBJ) $(SMP_FRAMEWORK_OBJ) $(SMP_CORE_OBJ) \
+	$(SMP_AES_OBJ) $(SMP_DEVICE_OBJ) $(SMP_DEVICE_INTRF_OBJ) $(SMP_STUB_OBJ)
+
 HEADERS := \
 	$(wildcard framework/*.h) \
 	$(wildcard controller/*.h) \
 	$(wildcard peer/*.h) \
+	$(wildcard link/*.h) \
+	$(wildcard oob/*.h) \
+	$(wildcard smp/*.h) \
 	$(wildcard $(ROOT)/include/bluetooth/*.h) \
+	$(wildcard $(ROOT)/include/crypto/*.h) \
+	$(ROOT)/include/device.h \
+	$(ROOT)/include/device_intrf.h \
 	$(ROOT)/include/istddef.h \
 	$(ROOT)/include/syslog.h
 
@@ -49,11 +75,16 @@ HEADERS := \
 
 all: test
 
-test: $(TARGET)
-	$(TEST_ENV) ./$(TARGET)
+test: $(TARGETS)
+	@set -e; \
+	for target in $(TARGETS); do \
+		echo "RUN $$target"; \
+		$(TEST_ENV) ./$$target; \
+	done
 
-strict: $(TARGET)
-	BT_COMPLIANCE_STRICT=1 $(TEST_ENV) ./$(TARGET)
+strict: $(TARGETS)
+	BT_COMPLIANCE_STRICT=1 $(TEST_ENV) ./$(HCI_TARGET)
+	$(TEST_ENV) ./$(SMP_TARGET)
 
 # cfifo is C, not C++: it uses C11 atomics that a C++ compiler rejects. The
 # controller layer needs it, so it is built as C and linked in.
@@ -66,10 +97,57 @@ $(CFIFO_OBJ): $(ROOT)/src/cfifo.c
 	@mkdir -p $(BUILD_DIR)
 	$(CC) $(CPPFLAGS) $(CFLAGS) $(SANITIZERS) -c $< -o $@
 
-$(TARGET): $(SOURCES) $(HEADERS) $(CFIFO_OBJ)
+$(HCI_TARGET): $(HCI_SOURCES) $(HEADERS) $(CFIFO_OBJ)
 	@mkdir -p $(BUILD_DIR)
 	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) \
-		$(SOURCES) $(CFIFO_OBJ) -o $@ $(LDFLAGS) $(SANITIZERS)
+		$(HCI_SOURCES) $(CFIFO_OBJ) -o $@ $(LDFLAGS) $(SANITIZERS)
+
+$(SMP_DIAG_SOURCE): smp/bt_smp_dual_host_test.cpp
+	@mkdir -p $(dir $@)
+	sed \
+		-e 's/centralIo <= BT_SMP_IOCAPS_KEYBOARD_DISPLAY/centralIo <= 0/' \
+		-e 's/peripheralIo <= BT_SMP_IOCAPS_KEYBOARD_DISPLAY/peripheralIo <= 0/' \
+		-e 's/mode < 3/mode < 1/' \
+		-e '/PairingRunResult result = RunPairing(cfg);/a\
+\t\tfprintf(stderr, "PAIR ci=%u pi=%u mitm=%d oob=%d periph=%d transport=%d complete=%d success=%d auth=%d sc=%d numeric=%d passkey=%d fail=0x%02x steps=%d\\n", cfg.CentralIo, cfg.PeripheralIo, cfg.Mitm, cfg.Oob, cfg.PeripheralStarts, result.TransportOk, result.Complete, result.Success, result.Authenticated, result.Sc, result.Numeric, result.Passkey, result.FailureReason, result.Steps);' \
+		-e '/PairingRunResult missingResult = RunPairing(missing);/a\
+\tfprintf(stderr, "OOB missing transport=%d complete=%d success=%d fail=0x%02x steps=%d\\n", missingResult.TransportOk, missingResult.Complete, missingResult.Success, missingResult.FailureReason, missingResult.Steps);' \
+		-e '/PairingRunResult corruptResult = RunPairing(corrupt);/a\
+\tfprintf(stderr, "OOB corrupt transport=%d complete=%d success=%d fail=0x%02x steps=%d\\n", corruptResult.TransportOk, corruptResult.Complete, corruptResult.Success, corruptResult.FailureReason, corruptResult.Steps);' \
+		$< > $@
+
+$(SMP_TEST_OBJ): $(SMP_DIAG_SOURCE) $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(SMP_TEST_RENAMES) $(CXXFLAGS) $(SANITIZERS) \
+		-c $< -o $@
+
+$(SMP_FRAMEWORK_OBJ): framework/bt_compliance.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_CORE_OBJ): $(ROOT)/src/bluetooth/bt_smp.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(SMP_CORE_DEFINES) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_AES_OBJ): $(ROOT)/src/crypto/crypto_softaes.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_DEVICE_OBJ): $(ROOT)/src/device.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_DEVICE_INTRF_OBJ): $(ROOT)/src/device_intrf.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_STUB_OBJ): smp/bt_smp_test_stubs.cpp $(HEADERS)
+	@mkdir -p $(dir $@)
+	$(CXX) $(SMP_CPPFLAGS) $(CXXFLAGS) $(SANITIZERS) -c $< -o $@
+
+$(SMP_TARGET): $(SMP_OBJECTS)
+	@mkdir -p $(BUILD_DIR)
+	$(CXX) $(SMP_OBJECTS) -o $@ $(LDFLAGS) $(SANITIZERS)
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/tests/bluetooth/compliance/link/bt_virtual_le_link.h
+++ b/tests/bluetooth/compliance/link/bt_virtual_le_link.h
@@ -1,0 +1,127 @@
+#ifndef BT_VIRTUAL_LE_LINK_H
+#define BT_VIRTUAL_LE_LINK_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace btcompliance {
+
+enum class LeAddressType : uint8_t {
+	Public = 0,
+	RandomStatic,
+	ResolvablePrivate,
+	NonResolvablePrivate,
+};
+
+enum class LeConnectionType : uint8_t {
+	LegacyUndirected = 0,
+	LegacyDirected,
+	Extended,
+};
+
+enum class SecurityInitiator : uint8_t {
+	Central = 0,
+	PeripheralRequest,
+};
+
+struct LeConnectionCase {
+	LeAddressType CentralAddress;
+	LeAddressType PeripheralAddress;
+	LeConnectionType Type;
+	SecurityInitiator SecurityStart;
+};
+
+class VirtualLeLink {
+public:
+	static constexpr size_t ADDRESS_TYPE_COUNT = 4;
+	static constexpr size_t CONNECTION_TYPE_COUNT = 3;
+	static constexpr size_t SECURITY_START_COUNT = 2;
+	static constexpr size_t CASE_COUNT = ADDRESS_TYPE_COUNT *
+		ADDRESS_TYPE_COUNT * CONNECTION_TYPE_COUNT * SECURITY_START_COUNT;
+
+	static LeConnectionCase CaseAt(size_t Index)
+	{
+		LeConnectionCase c = {};
+		c.SecurityStart = static_cast<SecurityInitiator>(Index % SECURITY_START_COUNT);
+		Index /= SECURITY_START_COUNT;
+		c.Type = static_cast<LeConnectionType>(Index % CONNECTION_TYPE_COUNT);
+		Index /= CONNECTION_TYPE_COUNT;
+		c.PeripheralAddress = static_cast<LeAddressType>(Index % ADDRESS_TYPE_COUNT);
+		Index /= ADDRESS_TYPE_COUNT;
+		c.CentralAddress = static_cast<LeAddressType>(Index % ADDRESS_TYPE_COUNT);
+		return c;
+	}
+
+	static bool Valid(const LeConnectionCase &Case)
+	{
+		return static_cast<uint8_t>(Case.CentralAddress) < ADDRESS_TYPE_COUNT &&
+			static_cast<uint8_t>(Case.PeripheralAddress) < ADDRESS_TYPE_COUNT &&
+			static_cast<uint8_t>(Case.Type) < CONNECTION_TYPE_COUNT &&
+			static_cast<uint8_t>(Case.SecurityStart) < SECURITY_START_COUNT;
+	}
+
+	VirtualLeLink() : vConnected(false), vCentralHandle(0), vPeripheralHandle(0),
+		vForwardedCentralToPeripheral(0), vForwardedPeripheralToCentral(0)
+	{
+	}
+
+	bool Connect(const LeConnectionCase &Case, uint16_t CentralHandle,
+		uint16_t PeripheralHandle)
+	{
+		if (vConnected || !Valid(Case) || CentralHandle == 0 || PeripheralHandle == 0)
+		{
+			return false;
+		}
+		vCase = Case;
+		vCentralHandle = CentralHandle;
+		vPeripheralHandle = PeripheralHandle;
+		vConnected = true;
+		return true;
+	}
+
+	void Disconnect()
+	{
+		vConnected = false;
+		vCentralHandle = 0;
+		vPeripheralHandle = 0;
+	}
+
+	bool ForwardFromCentral(const uint8_t *pData, size_t Len)
+	{
+		if (!vConnected || (Len != 0 && pData == nullptr))
+		{
+			return false;
+		}
+		vForwardedCentralToPeripheral += Len;
+		return true;
+	}
+
+	bool ForwardFromPeripheral(const uint8_t *pData, size_t Len)
+	{
+		if (!vConnected || (Len != 0 && pData == nullptr))
+		{
+			return false;
+		}
+		vForwardedPeripheralToCentral += Len;
+		return true;
+	}
+
+	bool Connected() const { return vConnected; }
+	uint16_t CentralHandle() const { return vCentralHandle; }
+	uint16_t PeripheralHandle() const { return vPeripheralHandle; }
+	size_t CentralToPeripheralBytes() const { return vForwardedCentralToPeripheral; }
+	size_t PeripheralToCentralBytes() const { return vForwardedPeripheralToCentral; }
+	const LeConnectionCase &ConnectionCase() const { return vCase; }
+
+private:
+	LeConnectionCase vCase = {};
+	bool vConnected;
+	uint16_t vCentralHandle;
+	uint16_t vPeripheralHandle;
+	size_t vForwardedCentralToPeripheral;
+	size_t vForwardedPeripheralToCentral;
+};
+
+} // namespace btcompliance
+
+#endif // BT_VIRTUAL_LE_LINK_H

--- a/tests/bluetooth/compliance/oob/bt_virtual_oob.h
+++ b/tests/bluetooth/compliance/oob/bt_virtual_oob.h
@@ -1,0 +1,90 @@
+#ifndef BT_VIRTUAL_OOB_H
+#define BT_VIRTUAL_OOB_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+namespace btcompliance {
+
+struct ScOobData {
+	uint8_t Random[16];
+	uint8_t Confirm[16];
+};
+
+enum class OobFault : uint8_t {
+	None = 0,
+	Drop,
+	CorruptRandom,
+	CorruptConfirm,
+	Replay,
+};
+
+class VirtualOobChannel {
+public:
+	VirtualOobChannel()
+	{
+		Reset();
+	}
+
+	void Reset()
+	{
+		memset(vData, 0, sizeof(vData));
+		memset(vValid, 0, sizeof(vValid));
+		memset(vConsumed, 0, sizeof(vConsumed));
+	}
+
+	bool Publish(unsigned Side, const ScOobData &Data)
+	{
+		if (Side > 1)
+		{
+			return false;
+		}
+		vData[Side] = Data;
+		vValid[Side] = true;
+		vConsumed[Side] = false;
+		return true;
+	}
+
+	bool Deliver(unsigned FromSide, ScOobData *pData, OobFault Fault)
+	{
+		if (FromSide > 1 || pData == nullptr || !vValid[FromSide])
+		{
+			return false;
+		}
+		if (Fault == OobFault::Drop)
+		{
+			return false;
+		}
+		if (vConsumed[FromSide] && Fault != OobFault::Replay)
+		{
+			return false;
+		}
+
+		*pData = vData[FromSide];
+		if (Fault == OobFault::CorruptRandom)
+		{
+			pData->Random[0] ^= 0x80;
+		}
+		else if (Fault == OobFault::CorruptConfirm)
+		{
+			pData->Confirm[15] ^= 0x01;
+		}
+		vConsumed[FromSide] = true;
+		return true;
+	}
+
+	bool Consumed(unsigned Side) const
+	{
+		return Side <= 1 && vConsumed[Side];
+	}
+
+private:
+	ScOobData vData[2];
+	bool vValid[2];
+	bool vConsumed[2];
+};
+
+} // namespace btcompliance
+
+#endif // BT_VIRTUAL_OOB_H

--- a/tests/bluetooth/compliance/smp/bt_l2cap_test_override.h
+++ b/tests/bluetooth/compliance/smp/bt_l2cap_test_override.h
@@ -1,0 +1,49 @@
+#ifndef BT_L2CAP_TEST_OVERRIDE_H
+#define BT_L2CAP_TEST_OVERRIDE_H
+
+// bt_l2cap.h intentionally declares variable-length protocol payloads with a
+// one-byte tail. The dual-host test receives complete SMP PDUs into fixed host
+// storage, so provide the same wire layout with a bounded tail before the
+// production headers are parsed. This affects only the host-test translation
+// units built with -include; the library ABI and embedded targets are unchanged.
+#ifndef __BT_L2CAP_H__
+#define __BT_L2CAP_H__
+
+#include <stdint.h>
+
+#include "bluetooth/bt_att.h"
+
+#define BT_L2CAP_CID_ATT       4
+#define BT_L2CAP_CID_SIGNAL    5
+#define BT_L2CAP_CID_SEC_MNGR  6
+#define BT_L2CAP_TEST_SMP_CAPACITY 96
+
+#pragma pack(push, 1)
+
+typedef struct __Bt_L2Cap_Header {
+	uint16_t Len;
+	uint16_t Cid;
+} BtL2CapHdr_t;
+
+typedef struct __Bt_L2Cap_Smp {
+	uint8_t Code;
+	uint8_t Data[BT_L2CAP_TEST_SMP_CAPACITY - 1];
+} BtL2CapSmp_t;
+
+typedef struct __Bt_L2Cap_Pdu {
+	BtL2CapHdr_t Hdr;
+	union {
+		BtAttReqRsp_t Att;
+		BtL2CapSmp_t Smp;
+	};
+} BtL2CapPdu_t;
+
+#pragma pack(pop)
+
+#ifndef BT_HCI_DEVICE_T_DEFINED
+#define BT_HCI_DEVICE_T_DEFINED
+typedef struct __Bt_Hci_Device BtHciDevice_t;
+#endif
+
+#endif // __BT_L2CAP_H__
+#endif // BT_L2CAP_TEST_OVERRIDE_H

--- a/tests/bluetooth/compliance/smp/bt_smp_dual_host_test.cpp
+++ b/tests/bluetooth/compliance/smp/bt_smp_dual_host_test.cpp
@@ -1,0 +1,1248 @@
+#include <errno.h>
+#include <poll.h>
+#include <signal.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "bluetooth/bt_gap.h"
+#include "bluetooth/bt_hci.h"
+#include "bluetooth/bt_l2cap.h"
+#include "bluetooth/bt_peer.h"
+#include "bluetooth/bt_smp.h"
+#include "bt_compliance.h"
+#include "bt_virtual_le_link.h"
+#include "bt_virtual_oob.h"
+
+namespace {
+
+using btcompliance::Context;
+using btcompliance::LeConnectionCase;
+using btcompliance::OobFault;
+using btcompliance::Requirement;
+using btcompliance::ScOobData;
+using btcompliance::VirtualLeLink;
+using btcompliance::VirtualOobChannel;
+
+constexpr uint16_t TEST_CONN_HDL = 1;
+constexpr size_t WIRE_DATA_SIZE = 96;
+constexpr int POLL_TIMEOUT_MS = 2000;
+constexpr int MAX_EVENT_STEPS = 20000;
+
+enum WireType : uint8_t {
+	WIRE_CMD_INIT = 1,
+	WIRE_CMD_GENERATE_OOB,
+	WIRE_CMD_SET_PEER_OOB,
+	WIRE_CMD_START_PAIRING,
+	WIRE_CMD_REQUEST_SECURITY,
+	WIRE_CMD_RX_SMP,
+	WIRE_CMD_LTK_REQUEST,
+	WIRE_CMD_ENCRYPTED,
+	WIRE_CMD_NUMERIC_REPLY,
+	WIRE_CMD_PASSKEY_REPLY,
+	WIRE_CMD_STOP,
+
+	WIRE_EVT_READY = 64,
+	WIRE_EVT_OOB_DATA,
+	WIRE_EVT_TX_SMP,
+	WIRE_EVT_ENABLE_ENCRYPTION,
+	WIRE_EVT_LTK_REPLY,
+	WIRE_EVT_LTK_NEG_REPLY,
+	WIRE_EVT_NUMERIC,
+	WIRE_EVT_PASSKEY_DISPLAY,
+	WIRE_EVT_PASSKEY_REQUEST,
+	WIRE_EVT_PAIRING_COMPLETE,
+	WIRE_EVT_ERROR,
+};
+
+struct WireMessage {
+	uint8_t Type;
+	uint8_t Length;
+	uint16_t Code;
+	uint32_t Value;
+	uint8_t Data[WIRE_DATA_SIZE];
+};
+
+static bool WriteAll(int Fd, const void *pData, size_t Len)
+{
+	const uint8_t *p = static_cast<const uint8_t *>(pData);
+	while (Len != 0)
+	{
+		ssize_t written = write(Fd, p, Len);
+		if (written < 0 && errno == EINTR)
+		{
+			continue;
+		}
+		if (written <= 0)
+		{
+			return false;
+		}
+		p += written;
+		Len -= static_cast<size_t>(written);
+	}
+	return true;
+}
+
+static bool ReadAll(int Fd, void *pData, size_t Len)
+{
+	uint8_t *p = static_cast<uint8_t *>(pData);
+	while (Len != 0)
+	{
+		ssize_t count = read(Fd, p, Len);
+		if (count < 0 && errno == EINTR)
+		{
+			continue;
+		}
+		if (count <= 0)
+		{
+			return false;
+		}
+		p += count;
+		Len -= static_cast<size_t>(count);
+	}
+	return true;
+}
+
+static bool SendWire(int Fd, const WireMessage &Message)
+{
+	return WriteAll(Fd, &Message, sizeof(Message));
+}
+
+static bool ReceiveWire(int Fd, WireMessage *pMessage)
+{
+	return pMessage != nullptr && ReadAll(Fd, pMessage, sizeof(*pMessage));
+}
+
+static uint32_t LoadLe32(const uint8_t *p)
+{
+	return static_cast<uint32_t>(p[0]) |
+		(static_cast<uint32_t>(p[1]) << 8) |
+		(static_cast<uint32_t>(p[2]) << 16) |
+		(static_cast<uint32_t>(p[3]) << 24);
+}
+
+static void StoreLe32(uint8_t *p, uint32_t Value)
+{
+	p[0] = static_cast<uint8_t>(Value);
+	p[1] = static_cast<uint8_t>(Value >> 8);
+	p[2] = static_cast<uint8_t>(Value >> 16);
+	p[3] = static_cast<uint8_t>(Value >> 24);
+}
+
+static uint64_t LoadLe64(const uint8_t *p)
+{
+	uint64_t value = 0;
+	for (int i = 7; i >= 0; i--)
+	{
+		value = (value << 8) | p[i];
+	}
+	return value;
+}
+
+static void StoreLe64(uint8_t *p, uint64_t Value)
+{
+	for (int i = 0; i < 8; i++)
+	{
+		p[i] = static_cast<uint8_t>(Value >> (i * 8));
+	}
+}
+
+struct TestKeyContext {
+	uint8_t PublicKey[64];
+};
+
+class TestCrypto final : public KeyAgreeEngine, public CipherEngine, public RngEngine {
+public:
+	TestCrypto() : vState(0xC001D00DU) {}
+
+	void Seed(uint32_t SeedValue)
+	{
+		vState = SeedValue != 0 ? SeedValue : 1;
+	}
+
+	bool Enable() override { return true; }
+	void Disable() override {}
+	void Reset() override {}
+	int SelfTest() override { return 0; }
+
+	size_t KeyCtxSize() const override { return sizeof(TestKeyContext); }
+	size_t KeyCtxAlign() const override { return alignof(TestKeyContext); }
+
+	void KeyReset(void *pKeyCtx) override
+	{
+		if (pKeyCtx != nullptr)
+		{
+			volatile uint8_t *p = static_cast<volatile uint8_t *>(pKeyCtx);
+			for (size_t i = 0; i < sizeof(TestKeyContext); i++)
+			{
+				p[i] = 0;
+			}
+		}
+	}
+
+	CRYPTO_STATUS KeyGen(CRYPTO_CURVE Curve, void *pKeyCtx,
+		uint8_t *pPublicKey) override
+	{
+		if (Curve != CRYPTO_CURVE_P256 || pKeyCtx == nullptr || pPublicKey == nullptr)
+		{
+			return CRYPTO_STATUS_FAIL;
+		}
+		TestKeyContext *pCtx = static_cast<TestKeyContext *>(pKeyCtx);
+		for (size_t i = 0; i < sizeof(pCtx->PublicKey); i++)
+		{
+			pCtx->PublicKey[i] = static_cast<uint8_t>(Next() | 1U);
+		}
+		memcpy(pPublicKey, pCtx->PublicKey, sizeof(pCtx->PublicKey));
+		return CRYPTO_STATUS_OK;
+	}
+
+	CRYPTO_STATUS Agree(CRYPTO_CURVE Curve, void *pKeyCtx,
+		const uint8_t *pPeerPublicKey, uint8_t *pSharedX,
+		bool bKeepKey = false) override
+	{
+		if (Curve != CRYPTO_CURVE_P256 || pKeyCtx == nullptr ||
+			pPeerPublicKey == nullptr || pSharedX == nullptr)
+		{
+			return CRYPTO_STATUS_FAIL;
+		}
+		TestKeyContext *pCtx = static_cast<TestKeyContext *>(pKeyCtx);
+		for (size_t i = 0; i < 32; i++)
+		{
+			pSharedX[i] = static_cast<uint8_t>(
+				pCtx->PublicKey[i] ^ pPeerPublicKey[i] ^
+				pCtx->PublicKey[32 + i] ^ pPeerPublicKey[32 + i] ^ 0x5AU);
+		}
+		if (!bKeepKey)
+		{
+			KeyReset(pKeyCtx);
+		}
+		return CRYPTO_STATUS_OK;
+	}
+
+	CRYPTO_STATUS Cipher(CRYPTO_CIPHER_ALG Alg, int bEncrypt,
+		const CryptoKey &Key, const uint8_t *pIv, size_t IvLen,
+		const uint8_t *pInput, size_t Len, uint8_t *pOutput) override
+	{
+		(void)bEncrypt;
+		(void)pIv;
+		(void)IvLen;
+		if (Alg != CRYPTO_CIPHER_ECB || Key.Type != CRYPTO_KEY_AES_128 ||
+			Key.Loc != CRYPTO_KEY_LOC_PLAIN || Key.Plain.pData == nullptr ||
+			Key.Plain.Len != 16 || pInput == nullptr || pOutput == nullptr || Len != 16)
+		{
+			return CRYPTO_STATUS_FAIL;
+		}
+
+		uint8_t state[16];
+		uint8_t next[16];
+		memcpy(state, pInput, sizeof(state));
+		for (uint8_t round = 0; round < 6; round++)
+		{
+			for (uint8_t i = 0; i < 16; i++)
+			{
+				uint8_t a = state[(i + 1U) & 15U];
+				uint8_t b = state[(i + 5U) & 15U];
+				uint8_t k = Key.Plain.pData[(i + round) & 15U];
+				uint8_t shift = static_cast<uint8_t>((i % 7U) + 1U);
+				uint8_t mixed = static_cast<uint8_t>(a + k + round + i);
+				next[i] = static_cast<uint8_t>((mixed << shift) |
+					(mixed >> (8U - shift)));
+				next[i] ^= b;
+			}
+			memcpy(state, next, sizeof(state));
+		}
+		memcpy(pOutput, state, sizeof(state));
+		return CRYPTO_STATUS_OK;
+	}
+
+	CRYPTO_STATUS Random(uint8_t *pOutput, size_t Len) override
+	{
+		if (pOutput == nullptr && Len != 0)
+		{
+			return CRYPTO_STATUS_FAIL;
+		}
+		for (size_t i = 0; i < Len; i++)
+		{
+			pOutput[i] = static_cast<uint8_t>(Next() >> 24);
+		}
+		return CRYPTO_STATUS_OK;
+	}
+
+	bool IsSecure() const override { return true; }
+
+private:
+	uint32_t Next()
+	{
+		uint32_t x = vState;
+		x ^= x << 13;
+		x ^= x >> 17;
+		x ^= x << 5;
+		vState = x;
+		return x;
+	}
+
+	uint32_t vState;
+};
+
+struct WorkerState {
+	int CommandFd;
+	int EventFd;
+	uint8_t Role;
+	uint8_t IoCaps;
+	uint8_t AuthReq;
+	uint8_t LocalAddrType;
+	uint8_t LocalAddr[6];
+	BtHciDevice_t Hci;
+	BtDevice_t Peer;
+	TestCrypto Crypto;
+	uint8_t LocalIrk[16];
+};
+
+static WorkerState *s_pWorker = nullptr;
+
+static bool WorkerEmit(uint8_t Type, uint16_t Code, uint32_t Value,
+	const void *pData, size_t Len)
+{
+	if (s_pWorker == nullptr || Len > WIRE_DATA_SIZE || (Len != 0 && pData == nullptr))
+	{
+		return false;
+	}
+	WireMessage message = {};
+	message.Type = Type;
+	message.Length = static_cast<uint8_t>(Len);
+	message.Code = Code;
+	message.Value = Value;
+	if (Len != 0)
+	{
+		memcpy(message.Data, pData, Len);
+	}
+	return SendWire(s_pWorker->EventFd, message);
+}
+
+static uint8_t WorkerHciCommand(BtHciDevice_t * const, uint16_t,
+	const void *, uint8_t, void *, uint8_t)
+{
+	return 0;
+}
+
+static bool WorkerInit(WorkerState *pWorker, const WireMessage &Message)
+{
+	if (pWorker == nullptr || Message.Length < 17)
+	{
+		return false;
+	}
+
+	pWorker->Role = Message.Data[0];
+	pWorker->IoCaps = Message.Data[1];
+	pWorker->AuthReq = Message.Data[2];
+	pWorker->LocalAddrType = Message.Data[3];
+	uint8_t peerAddrType = Message.Data[4];
+	memcpy(pWorker->LocalAddr, &Message.Data[5], 6);
+
+	memset(&pWorker->Hci, 0, sizeof(pWorker->Hci));
+	pWorker->Hci.pCtx = pWorker;
+	pWorker->Hci.Command = WorkerHciCommand;
+
+	memset(&pWorker->Peer, 0, sizeof(pWorker->Peer));
+	pWorker->Peer.Conn.Hdl = TEST_CONN_HDL;
+	pWorker->Peer.Conn.Role = pWorker->Role;
+	pWorker->Peer.Conn.PeerAddrType = peerAddrType;
+	memcpy(pWorker->Peer.Conn.PeerAddr, &Message.Data[11], 6);
+	pWorker->Peer.Conn.OwnAddrType = pWorker->LocalAddrType;
+	memcpy(pWorker->Peer.Conn.OwnAddr, pWorker->LocalAddr, 6);
+	pWorker->Peer.pHciDev = &pWorker->Hci;
+
+	for (size_t i = 0; i < sizeof(pWorker->LocalIrk); i++)
+	{
+		pWorker->LocalIrk[i] = static_cast<uint8_t>(0x80U + i + pWorker->Role);
+	}
+	pWorker->Crypto.Seed(pWorker->Role == BT_CONN_ROLE_CENTRAL ?
+		0x13579BDFU : 0x2468ACE1U);
+	if (!BtSmpInit(&pWorker->Crypto, &pWorker->Crypto, &pWorker->Crypto))
+	{
+		return false;
+	}
+	BtSmpAuthConfig(pWorker->IoCaps, pWorker->AuthReq);
+	return true;
+}
+
+static int WorkerMain(int CommandFd, int EventFd)
+{
+	WorkerState worker = {};
+	worker.CommandFd = CommandFd;
+	worker.EventFd = EventFd;
+	s_pWorker = &worker;
+
+	for (;;)
+	{
+		WireMessage message = {};
+		if (!ReceiveWire(CommandFd, &message))
+		{
+			break;
+		}
+
+		switch (message.Type)
+		{
+			case WIRE_CMD_INIT:
+				if (!WorkerInit(&worker, message))
+				{
+					WorkerEmit(WIRE_EVT_ERROR, 1, 0, nullptr, 0);
+					return 2;
+				}
+				WorkerEmit(WIRE_EVT_READY, 0, 0, nullptr, 0);
+				break;
+
+			case WIRE_CMD_GENERATE_OOB:
+			{
+				ScOobData data = {};
+				int rc = BtSmpOobLocalDataGen(&worker.Hci, data.Random, data.Confirm);
+				if (rc != 0)
+				{
+					WorkerEmit(WIRE_EVT_ERROR, 2, static_cast<uint32_t>(rc), nullptr, 0);
+				}
+				else
+				{
+					WorkerEmit(WIRE_EVT_OOB_DATA, 0, 0, &data, sizeof(data));
+				}
+				break;
+			}
+
+			case WIRE_CMD_SET_PEER_OOB:
+				if (message.Length == sizeof(ScOobData))
+				{
+					const ScOobData *pData = reinterpret_cast<const ScOobData *>(message.Data);
+					BtSmpOobPeerDataSet(pData->Random, pData->Confirm);
+				}
+				else
+				{
+					WorkerEmit(WIRE_EVT_ERROR, 3, message.Length, nullptr, 0);
+				}
+				break;
+
+			case WIRE_CMD_START_PAIRING:
+				BtSmpStartPairing(TEST_CONN_HDL);
+				break;
+
+			case WIRE_CMD_REQUEST_SECURITY:
+				BtSmpRequestSecurity(TEST_CONN_HDL);
+				break;
+
+			case WIRE_CMD_RX_SMP:
+			{
+				if (message.Length == 0 || message.Length > sizeof(BtL2CapSmp_t))
+				{
+					WorkerEmit(WIRE_EVT_ERROR, 4, message.Length, nullptr, 0);
+					break;
+				}
+				BtL2CapSmp_t smp = {};
+				memcpy(&smp, message.Data, message.Length);
+				BtProcessSmpData(&worker.Hci, TEST_CONN_HDL, &smp, message.Length);
+				break;
+			}
+
+			case WIRE_CMD_LTK_REQUEST:
+				if (message.Length >= 10)
+				{
+					uint64_t rand = LoadLe64(message.Data);
+					uint16_t ediv = static_cast<uint16_t>(message.Data[8] |
+						(static_cast<uint16_t>(message.Data[9]) << 8));
+					BtSmpProcessLtkRequest(&worker.Hci, TEST_CONN_HDL, rand, ediv);
+				}
+				break;
+
+			case WIRE_CMD_ENCRYPTED:
+				BtSmpEncryptionChanged(&worker.Hci, TEST_CONN_HDL,
+					static_cast<uint8_t>(message.Code), static_cast<uint8_t>(message.Value));
+				break;
+
+			case WIRE_CMD_NUMERIC_REPLY:
+				BtSmpNumericComparisonReply(TEST_CONN_HDL, message.Value != 0);
+				break;
+
+			case WIRE_CMD_PASSKEY_REPLY:
+				BtSmpPasskeyReply(TEST_CONN_HDL, message.Value);
+				break;
+
+			case WIRE_CMD_STOP:
+				BtSmpDisconnected(TEST_CONN_HDL);
+				return 0;
+
+			default:
+				WorkerEmit(WIRE_EVT_ERROR, 5, message.Type, nullptr, 0);
+				break;
+		}
+	}
+	return 0;
+}
+
+struct ChildPeer {
+	pid_t Pid;
+	int CommandFd;
+	int EventFd;
+	bool Complete;
+	bool Success;
+	bool Authenticated;
+	bool SecureConnections;
+	bool KeyValid;
+	bool NumericSeen;
+	uint32_t NumericValue;
+	bool PasskeyDisplaySeen;
+	uint32_t DisplayedPasskey;
+	bool PasskeyRequestSeen;
+	uint8_t FailureReason;
+};
+
+static bool SpawnPeer(ChildPeer *pPeer)
+{
+	int commandPipe[2];
+	int eventPipe[2];
+	if (pPeer == nullptr || pipe(commandPipe) != 0 || pipe(eventPipe) != 0)
+	{
+		return false;
+	}
+
+	pid_t pid = fork();
+	if (pid < 0)
+	{
+		close(commandPipe[0]);
+		close(commandPipe[1]);
+		close(eventPipe[0]);
+		close(eventPipe[1]);
+		return false;
+	}
+	if (pid == 0)
+	{
+		close(commandPipe[1]);
+		close(eventPipe[0]);
+		int rc = WorkerMain(commandPipe[0], eventPipe[1]);
+		close(commandPipe[0]);
+		close(eventPipe[1]);
+		_exit(rc);
+	}
+
+	close(commandPipe[0]);
+	close(eventPipe[1]);
+	memset(pPeer, 0, sizeof(*pPeer));
+	pPeer->Pid = pid;
+	pPeer->CommandFd = commandPipe[1];
+	pPeer->EventFd = eventPipe[0];
+	return true;
+}
+
+static void StopPeer(ChildPeer *pPeer)
+{
+	if (pPeer == nullptr || pPeer->Pid <= 0)
+	{
+		return;
+	}
+	WireMessage stop = {};
+	stop.Type = WIRE_CMD_STOP;
+	SendWire(pPeer->CommandFd, stop);
+	close(pPeer->CommandFd);
+	close(pPeer->EventFd);
+	int status = 0;
+	if (waitpid(pPeer->Pid, &status, 0) < 0)
+	{
+		kill(pPeer->Pid, SIGKILL);
+		waitpid(pPeer->Pid, &status, 0);
+	}
+	pPeer->Pid = 0;
+}
+
+static bool SendInit(ChildPeer *pPeer, uint8_t Role, uint8_t IoCaps,
+	uint8_t AuthReq, uint8_t LocalAddrType, const uint8_t LocalAddr[6],
+	uint8_t PeerAddrType, const uint8_t PeerAddr[6])
+{
+	WireMessage message = {};
+	message.Type = WIRE_CMD_INIT;
+	message.Length = 17;
+	message.Data[0] = Role;
+	message.Data[1] = IoCaps;
+	message.Data[2] = AuthReq;
+	message.Data[3] = LocalAddrType;
+	message.Data[4] = PeerAddrType;
+	memcpy(&message.Data[5], LocalAddr, 6);
+	memcpy(&message.Data[11], PeerAddr, 6);
+	if (!SendWire(pPeer->CommandFd, message))
+	{
+		return false;
+	}
+	WireMessage ready = {};
+	return ReceiveWire(pPeer->EventFd, &ready) && ready.Type == WIRE_EVT_READY;
+}
+
+static bool RequestOob(ChildPeer *pPeer, ScOobData *pData)
+{
+	WireMessage request = {};
+	request.Type = WIRE_CMD_GENERATE_OOB;
+	if (!SendWire(pPeer->CommandFd, request))
+	{
+		return false;
+	}
+	WireMessage response = {};
+	if (!ReceiveWire(pPeer->EventFd, &response) ||
+		response.Type != WIRE_EVT_OOB_DATA || response.Length != sizeof(*pData))
+	{
+		return false;
+	}
+	memcpy(pData, response.Data, sizeof(*pData));
+	return true;
+}
+
+static bool SetPeerOob(ChildPeer *pPeer, const ScOobData &Data)
+{
+	WireMessage message = {};
+	message.Type = WIRE_CMD_SET_PEER_OOB;
+	message.Length = sizeof(Data);
+	memcpy(message.Data, &Data, sizeof(Data));
+	return SendWire(pPeer->CommandFd, message);
+}
+
+struct PairingRunConfig {
+	uint8_t CentralIo;
+	uint8_t PeripheralIo;
+	bool Mitm;
+	bool Oob;
+	bool PeripheralStarts;
+	OobFault CentralReceives;
+	OobFault PeripheralReceives;
+};
+
+struct PairingRunResult {
+	bool TransportOk;
+	bool Complete;
+	bool Success;
+	bool Authenticated;
+	bool Sc;
+	bool Numeric;
+	bool Passkey;
+	bool Oob;
+	uint8_t FailureReason;
+	int Steps;
+};
+
+static uint8_t ExpectedModel(uint8_t CentralIo, uint8_t PeripheralIo,
+	bool Mitm, bool Oob)
+{
+	static const uint8_t map[5][5] = {
+		{ 0, 0, 2, 0, 2 },
+		{ 0, 1, 2, 0, 1 },
+		{ 2, 2, 2, 0, 2 },
+		{ 0, 0, 0, 0, 0 },
+		{ 2, 1, 2, 0, 1 },
+	};
+	if (Oob)
+	{
+		return BT_SMP_MODEL_OOB;
+	}
+	if (!Mitm)
+	{
+		return BT_SMP_MODEL_JUST_WORKS;
+	}
+	return map[CentralIo][PeripheralIo];
+}
+
+static bool ForwardSmp(ChildPeer *pDestination, const WireMessage &Event)
+{
+	WireMessage command = {};
+	command.Type = WIRE_CMD_RX_SMP;
+	command.Length = Event.Length;
+	memcpy(command.Data, Event.Data, Event.Length);
+	return SendWire(pDestination->CommandFd, command);
+}
+
+static bool SendNumericReply(ChildPeer *pPeer, bool Confirm)
+{
+	WireMessage message = {};
+	message.Type = WIRE_CMD_NUMERIC_REPLY;
+	message.Value = Confirm ? 1U : 0U;
+	return SendWire(pPeer->CommandFd, message);
+}
+
+static bool SendPasskeyReply(ChildPeer *pPeer, uint32_t Passkey)
+{
+	WireMessage message = {};
+	message.Type = WIRE_CMD_PASSKEY_REPLY;
+	message.Value = Passkey;
+	return SendWire(pPeer->CommandFd, message);
+}
+
+static void HandlePairingComplete(ChildPeer *pPeer, const WireMessage &Event)
+{
+	pPeer->Complete = true;
+	pPeer->Success = Event.Value != 0;
+	if (Event.Length >= 3)
+	{
+		pPeer->Authenticated = Event.Data[0] != 0;
+		pPeer->SecureConnections = Event.Data[1] != 0;
+		pPeer->KeyValid = Event.Data[2] != 0;
+	}
+}
+
+static PairingRunResult RunPairing(const PairingRunConfig &Config)
+{
+	PairingRunResult result = {};
+	ChildPeer central = {};
+	ChildPeer peripheral = {};
+	if (!SpawnPeer(&central) || !SpawnPeer(&peripheral))
+	{
+		StopPeer(&central);
+		StopPeer(&peripheral);
+		return result;
+	}
+
+	const uint8_t centralAddr[6] = { 0xC0, 0x10, 0x20, 0x30, 0x40, 0x50 };
+	const uint8_t peripheralAddr[6] = { 0xD0, 0x11, 0x21, 0x31, 0x41, 0x51 };
+	uint8_t auth = static_cast<uint8_t>(BT_SMP_AUTHREQ_BONDING_FLAG_BONDING |
+		BT_SMP_AUTHREQ_SC | (Config.Mitm ? BT_SMP_AUTHREQ_MITM : 0));
+
+	bool setup = SendInit(&central, BT_CONN_ROLE_CENTRAL, Config.CentralIo,
+		auth, 0, centralAddr, 0, peripheralAddr) &&
+		SendInit(&peripheral, BT_CONN_ROLE_PERIPHERAL, Config.PeripheralIo,
+			auth, 0, peripheralAddr, 0, centralAddr);
+
+	VirtualOobChannel oob;
+	if (setup && Config.Oob)
+	{
+		ScOobData centralData = {};
+		ScOobData peripheralData = {};
+		setup = RequestOob(&central, &centralData) &&
+			RequestOob(&peripheral, &peripheralData) &&
+			oob.Publish(0, centralData) && oob.Publish(1, peripheralData);
+		ScOobData delivered = {};
+		if (setup && oob.Deliver(1, &delivered, Config.CentralReceives))
+		{
+			setup = SetPeerOob(&central, delivered);
+		}
+		else if (Config.CentralReceives != OobFault::Drop)
+		{
+			setup = false;
+		}
+		if (setup && oob.Deliver(0, &delivered, Config.PeripheralReceives))
+		{
+			setup = SetPeerOob(&peripheral, delivered);
+		}
+		else if (Config.PeripheralReceives != OobFault::Drop)
+		{
+			setup = false;
+		}
+	}
+
+	WireMessage start = {};
+	start.Type = Config.PeripheralStarts ? WIRE_CMD_REQUEST_SECURITY : WIRE_CMD_START_PAIRING;
+	if (setup)
+	{
+		setup = SendWire(Config.PeripheralStarts ? peripheral.CommandFd : central.CommandFd,
+			start);
+	}
+
+	bool encryptionPending = false;
+	uint8_t centralLtk[16] = {};
+	bool numericRepliesSent = false;
+	bool passkeyReplySent = false;
+	int idlePolls = 0;
+
+	for (int step = 0; setup && step < MAX_EVENT_STEPS; step++)
+	{
+		result.Steps = step + 1;
+		if (central.Complete && peripheral.Complete)
+		{
+			break;
+		}
+		if (central.FailureReason != 0 || peripheral.FailureReason != 0)
+		{
+			if (++idlePolls > 2)
+			{
+				break;
+			}
+		}
+
+		pollfd fds[2] = {
+			{ central.EventFd, POLLIN, 0 },
+			{ peripheral.EventFd, POLLIN, 0 },
+		};
+		int ready = poll(fds, 2, POLL_TIMEOUT_MS);
+		if (ready <= 0)
+		{
+			setup = false;
+			break;
+		}
+
+		for (int side = 0; side < 2; side++)
+		{
+			if ((fds[side].revents & POLLIN) == 0)
+			{
+				continue;
+			}
+			ChildPeer *pSource = side == 0 ? &central : &peripheral;
+			ChildPeer *pDestination = side == 0 ? &peripheral : &central;
+			WireMessage event = {};
+			if (!ReceiveWire(pSource->EventFd, &event))
+			{
+				setup = false;
+				break;
+			}
+
+			switch (event.Type)
+			{
+				case WIRE_EVT_TX_SMP:
+					if (event.Length >= 2 && event.Data[0] == BT_SMP_CODE_PAIRING_FAILED)
+					{
+						pSource->FailureReason = event.Data[1];
+					}
+					setup = ForwardSmp(pDestination, event);
+					break;
+
+				case WIRE_EVT_ENABLE_ENCRYPTION:
+				{
+					if (event.Length != 26)
+					{
+						setup = false;
+						break;
+					}
+					memcpy(centralLtk, &event.Data[10], 16);
+					WireMessage ltk = {};
+					ltk.Type = WIRE_CMD_LTK_REQUEST;
+					ltk.Length = 10;
+					memcpy(ltk.Data, event.Data, 10);
+					setup = SendWire(peripheral.CommandFd, ltk);
+					encryptionPending = true;
+					break;
+				}
+
+				case WIRE_EVT_LTK_REPLY:
+				{
+					if (!encryptionPending || event.Length != 16 ||
+						memcmp(event.Data, centralLtk, 16) != 0)
+					{
+						setup = false;
+						break;
+					}
+					WireMessage encrypted = {};
+					encrypted.Type = WIRE_CMD_ENCRYPTED;
+					encrypted.Code = 0;
+					encrypted.Value = 1;
+					setup = SendWire(central.CommandFd, encrypted) &&
+						SendWire(peripheral.CommandFd, encrypted);
+					encryptionPending = false;
+					break;
+				}
+
+				case WIRE_EVT_LTK_NEG_REPLY:
+					setup = false;
+					break;
+
+				case WIRE_EVT_NUMERIC:
+					pSource->NumericSeen = true;
+					pSource->NumericValue = event.Value;
+					break;
+
+				case WIRE_EVT_PASSKEY_DISPLAY:
+					pSource->PasskeyDisplaySeen = true;
+					pSource->DisplayedPasskey = event.Value;
+					break;
+
+				case WIRE_EVT_PASSKEY_REQUEST:
+					pSource->PasskeyRequestSeen = true;
+					break;
+
+				case WIRE_EVT_PAIRING_COMPLETE:
+					HandlePairingComplete(pSource, event);
+					break;
+
+				case WIRE_EVT_ERROR:
+					setup = false;
+					break;
+
+				default:
+					setup = false;
+					break;
+			}
+		}
+
+		if (setup && central.NumericSeen && peripheral.NumericSeen &&
+			!numericRepliesSent)
+		{
+			bool match = central.NumericValue == peripheral.NumericValue;
+			setup = SendNumericReply(&central, match) &&
+				SendNumericReply(&peripheral, match);
+			numericRepliesSent = true;
+		}
+
+		if (setup && !passkeyReplySent)
+		{
+			if (central.PasskeyDisplaySeen && peripheral.PasskeyRequestSeen)
+			{
+				setup = SendPasskeyReply(&peripheral, central.DisplayedPasskey);
+				passkeyReplySent = true;
+			}
+			else if (peripheral.PasskeyDisplaySeen && central.PasskeyRequestSeen)
+			{
+				setup = SendPasskeyReply(&central, peripheral.DisplayedPasskey);
+				passkeyReplySent = true;
+			}
+		}
+	}
+
+	result.TransportOk = setup;
+	result.Complete = central.Complete && peripheral.Complete;
+	result.Success = result.Complete && central.Success && peripheral.Success;
+	result.Authenticated = result.Success && central.Authenticated && peripheral.Authenticated;
+	result.Sc = result.Success && central.SecureConnections && peripheral.SecureConnections;
+	result.Numeric = central.NumericSeen && peripheral.NumericSeen;
+	result.Passkey = (central.PasskeyDisplaySeen && peripheral.PasskeyRequestSeen) ||
+		(peripheral.PasskeyDisplaySeen && central.PasskeyRequestSeen);
+	result.Oob = Config.Oob;
+	result.FailureReason = central.FailureReason != 0 ?
+		central.FailureReason : peripheral.FailureReason;
+
+	StopPeer(&central);
+	StopPeer(&peripheral);
+	return result;
+}
+
+static void TestConnectionMatrix(Context &ctx)
+{
+	static const Requirement req = {
+		"GAP-CONN-MATRIX-BV-01", "Core Vol 3 Part C", "9.3",
+		"Central and Peripheral role, address, connection-procedure and security-initiator combinations are enumerated"
+	};
+	ctx.Begin(req);
+
+	bool seen[4][4][3][2] = {};
+	uint8_t payload[7] = { 1, 2, 3, 4, 5, 6, 7 };
+	for (size_t i = 0; i < VirtualLeLink::CASE_COUNT; i++)
+	{
+		LeConnectionCase c = VirtualLeLink::CaseAt(i);
+		BT_CHECK(ctx, VirtualLeLink::Valid(c));
+		unsigned ca = static_cast<unsigned>(c.CentralAddress);
+		unsigned pa = static_cast<unsigned>(c.PeripheralAddress);
+		unsigned ct = static_cast<unsigned>(c.Type);
+		unsigned si = static_cast<unsigned>(c.SecurityStart);
+		BT_CHECK(ctx, !seen[ca][pa][ct][si]);
+		seen[ca][pa][ct][si] = true;
+
+		VirtualLeLink link;
+		BT_CHECK(ctx, link.Connect(c, 1, 2));
+		BT_CHECK(ctx, link.Connected());
+		BT_CHECK(ctx, link.CentralHandle() == 1);
+		BT_CHECK(ctx, link.PeripheralHandle() == 2);
+		BT_CHECK(ctx, link.ForwardFromCentral(payload, sizeof(payload)));
+		BT_CHECK(ctx, link.ForwardFromPeripheral(payload, sizeof(payload) - 2));
+		BT_CHECK(ctx, link.CentralToPeripheralBytes() == sizeof(payload));
+		BT_CHECK(ctx, link.PeripheralToCentralBytes() == sizeof(payload) - 2);
+		link.Disconnect();
+		BT_CHECK(ctx, !link.Connected());
+	}
+	ctx.End();
+}
+
+static void TestOobChannelIsolation(Context &ctx)
+{
+	static const Requirement req = {
+		"SMP-OOB-CHANNEL-BV-01", "Core Vol 3 Part H", "2.3.5.6.4",
+		"SC OOB material moves through a separate single-use channel with drop, corruption and replay controls"
+	};
+	ctx.Begin(req);
+
+	VirtualOobChannel channel;
+	ScOobData a = {};
+	ScOobData b = {};
+	for (size_t i = 0; i < 16; i++)
+	{
+		a.Random[i] = static_cast<uint8_t>(i);
+		a.Confirm[i] = static_cast<uint8_t>(0x20 + i);
+		b.Random[i] = static_cast<uint8_t>(0x40 + i);
+		b.Confirm[i] = static_cast<uint8_t>(0x60 + i);
+	}
+	BT_CHECK(ctx, channel.Publish(0, a));
+	BT_CHECK(ctx, channel.Publish(1, b));
+	ScOobData out = {};
+	BT_CHECK(ctx, channel.Deliver(0, &out, OobFault::None));
+	BT_CHECK(ctx, memcmp(&out, &a, sizeof(out)) == 0);
+	BT_CHECK(ctx, !channel.Deliver(0, &out, OobFault::None));
+	BT_CHECK(ctx, channel.Deliver(0, &out, OobFault::Replay));
+	BT_CHECK(ctx, channel.Deliver(1, &out, OobFault::CorruptRandom));
+	BT_CHECK(ctx, out.Random[0] == static_cast<uint8_t>(b.Random[0] ^ 0x80));
+	channel.Reset();
+	BT_CHECK(ctx, !channel.Deliver(0, &out, OobFault::None));
+	ctx.End();
+}
+
+static void TestAssociationMatrix(Context &ctx)
+{
+	static const Requirement req = {
+		"SMP-SC-ASSOC-BV-01", "Core Vol 3 Part H", "2.3.5.1 and 2.3.5.6",
+		"all IO-capability pairs complete through the selected SC association model, including OOB"
+	};
+	ctx.Begin(req);
+
+	for (uint8_t centralIo = 0; centralIo <= BT_SMP_IOCAPS_KEYBOARD_DISPLAY; centralIo++)
+	{
+		for (uint8_t peripheralIo = 0; peripheralIo <= BT_SMP_IOCAPS_KEYBOARD_DISPLAY; peripheralIo++)
+		{
+			for (int mode = 0; mode < 3; mode++)
+			{
+				PairingRunConfig cfg = {};
+				cfg.CentralIo = centralIo;
+				cfg.PeripheralIo = peripheralIo;
+				cfg.Mitm = mode != 0;
+				cfg.Oob = mode == 2;
+				cfg.CentralReceives = OobFault::None;
+				cfg.PeripheralReceives = OobFault::None;
+				PairingRunResult result = RunPairing(cfg);
+				uint8_t model = ExpectedModel(centralIo, peripheralIo, cfg.Mitm, cfg.Oob);
+
+				BT_CHECK(ctx, result.TransportOk);
+				BT_CHECK(ctx, result.Complete);
+				BT_CHECK(ctx, result.Success);
+				BT_CHECK(ctx, result.Sc);
+				BT_CHECK(ctx, result.Authenticated ==
+					(model != BT_SMP_MODEL_JUST_WORKS));
+				BT_CHECK(ctx, result.Numeric ==
+					(model == BT_SMP_MODEL_NUMERIC_COMPARISON));
+				BT_CHECK(ctx, result.Passkey ==
+					(model == BT_SMP_MODEL_PASSKEY_ENTRY));
+			}
+		}
+	}
+	ctx.End();
+}
+
+static void TestPeripheralSecurityRequest(Context &ctx)
+{
+	static const Requirement req = {
+		"SMP-SEC-REQ-BV-01", "Core Vol 3 Part H", "2.4.6 and 3.6.7",
+		"a Peripheral Security Request causes the Central to initiate each supported SC association model"
+	};
+	ctx.Begin(req);
+
+	const PairingRunConfig cases[] = {
+		{ BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT, BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+			false, false, true, OobFault::None, OobFault::None },
+		{ BT_SMP_IOCAPS_DISPLAY_YESNO, BT_SMP_IOCAPS_DISPLAY_YESNO,
+			true, false, true, OobFault::None, OobFault::None },
+		{ BT_SMP_IOCAPS_DISPLAY_ONLY, BT_SMP_IOCAPS_KEYBOARD_ONLY,
+			true, false, true, OobFault::None, OobFault::None },
+		{ BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT, BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+			true, true, true, OobFault::None, OobFault::None },
+	};
+
+	for (const PairingRunConfig &cfg : cases)
+	{
+		PairingRunResult result = RunPairing(cfg);
+		BT_CHECK(ctx, result.TransportOk);
+		BT_CHECK(ctx, result.Complete);
+		BT_CHECK(ctx, result.Success);
+		BT_CHECK(ctx, result.Sc);
+	}
+	ctx.End();
+}
+
+static void TestOobFailures(Context &ctx)
+{
+	static const Requirement req = {
+		"SMP-SC-OOB-BI-01", "Core Vol 3 Part H", "2.3.5.6.4",
+		"missing or corrupted SC OOB data cannot produce an authenticated encrypted link"
+	};
+	ctx.Begin(req);
+
+	PairingRunConfig missing = {
+		BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+		BT_SMP_IOCAPS_NO_INPUT_NO_OUTPUT,
+		true, true, false, OobFault::Drop, OobFault::None
+	};
+	PairingRunResult missingResult = RunPairing(missing);
+	BT_CHECK(ctx, !missingResult.Success);
+	BT_CHECK(ctx, missingResult.FailureReason == BT_SMP_ERR_OOB_NOT_AVAILABLE);
+
+	PairingRunConfig corrupt = missing;
+	corrupt.CentralReceives = OobFault::CorruptConfirm;
+	PairingRunResult corruptResult = RunPairing(corrupt);
+	BT_CHECK(ctx, !corruptResult.Success);
+	BT_CHECK(ctx, corruptResult.FailureReason != 0);
+	ctx.End();
+}
+
+} // namespace
+
+extern "C" {
+
+void CryptoSecureWipe(void *pData, size_t Len)
+{
+	volatile uint8_t *p = static_cast<volatile uint8_t *>(pData);
+	while (Len-- != 0)
+	{
+		*p++ = 0;
+	}
+}
+
+BtDevice_t *BtPeerFindByHdl(uint16_t ConnHdl)
+{
+	return s_pWorker != nullptr && s_pWorker->Peer.Conn.Hdl == ConnHdl ?
+		&s_pWorker->Peer : nullptr;
+}
+
+uint8_t BtPeerRole(uint16_t ConnHdl)
+{
+	BtDevice_t *pPeer = BtPeerFindByHdl(ConnHdl);
+	return pPeer != nullptr ? pPeer->Conn.Role : BT_CONN_ROLE_UNKNOWN;
+}
+
+uint16_t BtPeerActiveHdl(void)
+{
+	return s_pWorker != nullptr ? s_pWorker->Peer.Conn.Hdl : BT_CONN_HDL_INVALID;
+}
+
+bool BtGapConnSecGet(uint16_t ConnHdl, BtConnSec_t *pSec)
+{
+	BtDevice_t *pPeer = BtPeerFindByHdl(ConnHdl);
+	if (pPeer == nullptr || pSec == nullptr)
+	{
+		return false;
+	}
+	*pSec = pPeer->Conn.Sec;
+	return true;
+}
+
+void BtGapConnSecSet(uint16_t ConnHdl, const BtConnSec_t *pSec)
+{
+	BtDevice_t *pPeer = BtPeerFindByHdl(ConnHdl);
+	if (pPeer != nullptr && pSec != nullptr)
+	{
+		pPeer->Conn.Sec = *pSec;
+		pPeer->bSecure = pSec->Level != BT_GAP_SEC_LEVEL_NONE;
+	}
+}
+
+uint32_t BtHciSendAcl(BtHciDevice_t * const, BtHciACLDataPacket_t * const pAcl)
+{
+	if (pAcl == nullptr || pAcl->Hdr.Len < sizeof(BtL2CapHdr_t))
+	{
+		return 0;
+	}
+	BtL2CapPdu_t *pL2 = reinterpret_cast<BtL2CapPdu_t *>(pAcl->Data);
+	if (pL2->Hdr.Cid != BT_L2CAP_CID_SEC_MNGR || pL2->Hdr.Len > WIRE_DATA_SIZE)
+	{
+		return 0;
+	}
+	const uint8_t *pSmp = reinterpret_cast<const uint8_t *>(&pL2->Smp);
+	if (!WorkerEmit(WIRE_EVT_TX_SMP, pSmp[0], 0, pSmp, pL2->Hdr.Len))
+	{
+		return 0;
+	}
+	return static_cast<uint32_t>(sizeof(BtHciACLDataPacketHdr_t) + pAcl->Hdr.Len);
+}
+
+void BtSmpHciEnableEncryption(BtHciDevice_t * const, uint16_t,
+	uint64_t Rand, uint16_t Ediv, const uint8_t Ltk[16])
+{
+	uint8_t data[26] = {};
+	StoreLe64(data, Rand);
+	data[8] = static_cast<uint8_t>(Ediv);
+	data[9] = static_cast<uint8_t>(Ediv >> 8);
+	memcpy(&data[10], Ltk, 16);
+	WorkerEmit(WIRE_EVT_ENABLE_ENCRYPTION, 0, 0, data, sizeof(data));
+}
+
+void BtSmpHciLtkReply(BtHciDevice_t * const, uint16_t, const uint8_t Ltk[16])
+{
+	WorkerEmit(WIRE_EVT_LTK_REPLY, 0, 0, Ltk, 16);
+}
+
+void BtSmpHciLtkNegReply(BtHciDevice_t * const, uint16_t)
+{
+	WorkerEmit(WIRE_EVT_LTK_NEG_REPLY, 0, 0, nullptr, 0);
+}
+
+void BtSmpNumericComparison(uint16_t, uint32_t Value)
+{
+	WorkerEmit(WIRE_EVT_NUMERIC, 0, Value, nullptr, 0);
+}
+
+void BtSmpPasskeyDisplay(uint16_t, uint32_t Passkey)
+{
+	WorkerEmit(WIRE_EVT_PASSKEY_DISPLAY, 0, Passkey, nullptr, 0);
+}
+
+void BtSmpPasskeyRequest(uint16_t)
+{
+	WorkerEmit(WIRE_EVT_PASSKEY_REQUEST, 0, 0, nullptr, 0);
+}
+
+void BtSmpPairingComplete(uint16_t, bool Success, const BtSmpKeys_t *pKeys)
+{
+	uint8_t data[3] = {};
+	if (pKeys != nullptr)
+	{
+		data[0] = pKeys->bAuthenticated ? 1 : 0;
+		data[1] = pKeys->bSc ? 1 : 0;
+		data[2] = pKeys->bValid ? 1 : 0;
+	}
+	WorkerEmit(WIRE_EVT_PAIRING_COMPLETE, 0, Success ? 1U : 0U,
+		data, sizeof(data));
+}
+
+void BtSmpLocalAddrGet(uint8_t *pType, uint8_t pAddr[6])
+{
+	if (s_pWorker != nullptr)
+	{
+		*pType = s_pWorker->LocalAddrType;
+		memcpy(pAddr, s_pWorker->LocalAddr, 6);
+	}
+	else
+	{
+		*pType = 0;
+		memset(pAddr, 0, 6);
+	}
+}
+
+bool BtSmpLocalIrkGet(uint8_t Irk[16])
+{
+	if (s_pWorker == nullptr || Irk == nullptr)
+	{
+		return false;
+	}
+	memcpy(Irk, s_pWorker->LocalIrk, 16);
+	return true;
+}
+
+void BtSmpBondLoad(void) {}
+void BtSmpBondSave(int, const void *, size_t) {}
+void BtSmpBondErase(void) {}
+void BtSmpLocalIdSave(void) {}
+size_t BtSmpLocalIdRecordSize(void) { return 0; }
+size_t BtSmpLocalIdSerialize(void *, size_t) { return 0; }
+bool BtSmpLocalIdRestore(const void *, size_t) { return false; }
+
+bool BtSmpBondKeysLookup(uint16_t, uint64_t, uint16_t, BtSmpKeys_t *)
+{
+	return false;
+}
+
+bool BtSmpBonded(uint16_t)
+{
+	return false;
+}
+
+void BtSmpBondCccdSave(uint16_t, uint16_t, uint16_t) {}
+uint8_t BtSmpBondCccdGet(uint16_t, uint16_t *, uint16_t *, uint8_t)
+{
+	return 0;
+}
+
+} // extern "C"
+
+int main()
+{
+	Context ctx("Bluetooth dual-host connection and SMP compliance");
+	TestConnectionMatrix(ctx);
+	TestOobChannelIsolation(ctx);
+	TestAssociationMatrix(ctx);
+	TestPeripheralSecurityRequest(ctx);
+	TestOobFailures(ctx);
+	return ctx.Finish(false);
+}

--- a/tests/bluetooth/compliance/smp/bt_smp_test_stubs.cpp
+++ b/tests/bluetooth/compliance/smp/bt_smp_test_stubs.cpp
@@ -1,0 +1,71 @@
+#include <signal.h>
+#include <stdarg.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <unistd.h>
+
+#include "bluetooth/bt_gatt.h"
+#include "bluetooth/bt_smp.h"
+#include "crypto/crypto_softaes.h"
+#include "syslog.h"
+
+namespace {
+
+CryptoSoftAes s_Aes;
+
+__attribute__((constructor)) void IgnoreBrokenPipeSignal()
+{
+	// A worker can terminate after reporting a fatal protocol error. The parent
+	// still owns the pipe long enough to collect that result; writing the final
+	// stop message must return EPIPE rather than terminate the whole test process.
+	signal(SIGPIPE, SIG_IGN);
+}
+
+} // namespace
+
+extern "C" {
+
+// bt_smp.cpp is compiled with its initializer renamed for this host test. The
+// wrapper keeps deterministic ECDH and RNG from each worker but replaces the
+// temporary test mixer with IOsonata's production AES-128 implementation.
+bool BtSmpInitReal(KeyAgreeEngine *pEcdh, CipherEngine *pAes, RngEngine *pRng);
+
+bool BtSmpInit(KeyAgreeEngine *pEcdh, CipherEngine *pAes, RngEngine *pRng)
+{
+	(void)pAes;
+	if (!s_Aes.Enable())
+	{
+		return false;
+	}
+	return BtSmpInitReal(pEcdh, &s_Aes, pRng);
+}
+
+void BtGattCccdRestoreBonded(uint16_t ConnHdl)
+{
+	(void)ConnHdl;
+}
+
+SysLog_t *SysLogGet(void)
+{
+	static SysLog_t log = {};
+	return &log;
+}
+
+int SysLogPrintf(SysLog_t * const pLog, const char *pFormat, ...)
+{
+	(void)pLog;
+	static unsigned count;
+	if (count++ >= 24 || pFormat == nullptr)
+	{
+		return 0;
+	}
+
+	fprintf(stderr, "[smp-worker %ld] ", (long)getpid());
+	va_list args;
+	va_start(args, pFormat);
+	int result = vfprintf(stderr, pFormat, args);
+	va_end(args);
+	return result;
+}
+
+} // extern "C"

--- a/tests/bluetooth/host/bt_peer_pool_test.cpp
+++ b/tests/bluetooth/host/bt_peer_pool_test.cpp
@@ -171,6 +171,16 @@ void TestPeerRole()
 	// No record for this handle.
 	CHECK(BtPeerRole(0x77) == BT_CONN_ROLE_UNKNOWN);
 
+	// A slot that has been allocated but whose role has not been filled in
+	// reports UNKNOWN, not CENTRAL. BT_CONN_ROLE_CENTRAL is 0, so a zeroed
+	// record used to read as a central link, and the SMP and L2CAP role gates
+	// refuse a PDU on that reading: a peripheral would answer a Pairing
+	// Request with Command Not Supported.
+	BtDevice_t *raw = BtPeerAlloc(0x13);
+	CHECK(raw != nullptr);
+	CHECK(BtPeerRole(0x13) == BT_CONN_ROLE_UNKNOWN);
+	BtPeerFree(raw);
+
 	// A value outside the HCI encoding (a BT_GAP_ROLE_* bitmask, 0x0C for
 	// PERIPHERAL|CENTRAL) reports UNKNOWN rather than a role.
 	BtDevice_t *bogus = BtPeerConnected(0x12, 0x0C, 0, addr, 0, nullptr);


### PR DESCRIPTION
Synchronize the prematurely merged bt_conformance head into the dual-host repair branch before applying the production OOB correction and restoring the full matrix.