### PR TITLE
Trigger bt_conformance repair workflow

### DIFF
--- a/tools/.bt_conformance_autofix_trigger
+++ b/tools/.bt_conformance_autofix_trigger
@@ -1,1 +1,1 @@
-Trigger the one-shot bt_conformance repair workflow, attempt 2.
+Trigger the one-shot bt_conformance repair workflow, attempt 3.

--- a/tools/.bt_conformance_autofix_trigger
+++ b/tools/.bt_conformance_autofix_trigger
@@ -1,1 +1,1 @@
-Trigger the one-shot bt_conformance repair workflow, attempt 3.
+Trigger the one-shot bt_conformance repair workflow, attempt 4.

--- a/tools/.bt_conformance_autofix_trigger
+++ b/tools/.bt_conformance_autofix_trigger
@@ -1,0 +1,1 @@
+Trigger the one-shot bt_conformance repair workflow.

--- a/tools/.bt_conformance_autofix_trigger
+++ b/tools/.bt_conformance_autofix_trigger
@@ -1,1 +1,1 @@
-Trigger the one-shot bt_conformance repair workflow.
+Trigger the one-shot bt_conformance repair workflow, attempt 2.


### PR DESCRIPTION
Temporary same-repository PR used to run the one-shot repair and host/compliance validation against `bt_conformance`. It will be closed after the repair commit is produced.